### PR TITLE
mod_audio_fork: prefix every session-bound log line with the channel UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ live-credentials soak (see `docs/TESTING.md`).
 
 ---
 
+## v0.6.3 — 2026-07-02
+Docs only — a docs-vs-code audit found two shipped claims contradicting the
+code after v0.6.1:
+- `modules/mod_audio_fork/README.md` still said `MOD_AUDIO_FORK_SERVICE_THREADS`
+  "can be set to as many as 5"; values above 1 have been capped to 1 since
+  v0.6.1 (multi-context connect adoption is not thread-safe).
+- `tests/soak/README.md` still described the soak as `mod_audio_fork`-only; it
+  has built and run the `mod_deepgram_transcribe` AudioPipe soak as well since
+  v0.6.0 (now documented, including what the TLS-only deepgram variant does and
+  does not exercise, and the lws-only `tsan.supp` suppression).
+
 ## v0.6.2 — 2026-07-02
 Docs only.
 - `docs/TESTING.md`: the Layer-3 load gate no longer recommends `fs_cli -x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ live-credentials soak (see `docs/TESTING.md`).
 
 ---
 
+## v0.5.2 — 2026-06-28 (`7551c4b`, `0925fe1`)
+AudioPipe teardown use-after-free fix (`mod_audio_fork`, `mod_deepgram_transcribe`).
+**[build] [tsan]**
+
+- **The lws service thread reads `(*it)->m_state` for every entry in the pending
+  connect/disconnect/write lists (under each list's mutex), but the reaper could
+  `delete` an AudioPipe still present in `pendingWrites`** — a write queued by the
+  media thread's last `unlockAudioBuffer` just before teardown. Result: a
+  heap-use-after-free read of `m_state` on the lws thread. → `~AudioPipe()` now
+  calls `removeFromPending(this)`, removing the pipe from all three lists under
+  those lists' mutexes, so the read is serialized with the free (present-and-alive,
+  or already-gone — never read after free; locks taken one at a time, no deadlock).
+- Found reproducibly under **ThreadSanitizer** in the structurally-identical
+  `mod_ttsd_transcribe` AudioPipe (a fork of this code, in its own repo); the fix
+  is identical across all three. `mod_audio_fork`'s `tests/soak` (ASan + TSan,
+  200×4 scenarios) stays clean with the fix. It did not reproduce on that soak's
+  `close()`-based reaper (narrower window), so for the in-repo modules this is a
+  defensive backport of a verified fix.
+
 ## v0.5.1 — 2026-06-25 (`65f2a45`)
 Docs only.
 - Added `docs/TESTING.md`: the reproducible 5-layer testing methodology, gotchas,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,65 @@ live-credentials soak (see `docs/TESTING.md`).
 
 ---
 
+## v0.6.1 — 2026-07-02
+
+Completes the v0.6.0 review: the shared-lineage AudioPipe fixes ported to
+`mod_audio_fork`, and both aws deferrals resolved against the actual
+aws-sdk-cpp source. **[unit] [build] [tsan]**
+
+- **mod_audio_fork** (5 commits, one per issue — the deepgram v0.6.0 fixes in
+  its identical lws transport):
+  - `close()` racing the WS handshake leaked the pipe/thread/socket forever
+    (reaper blocked in `waitForClose()`); completed via a pending-close flag
+    at ESTABLISHED, same pattern as deepgram/ttsd `finish()`.
+  - Oversized/alloc-failed inbound messages could deliver a truncated tail to
+    the JSON parser as a complete message; unchecked first-fragment malloc;
+    realloc-failure leak with poisoned fragment math.
+  - `~AudioPipe()` `delete[]`d the malloc'd recv buffer; `lws_write` failures
+    hidden by the signed/unsigned comparison.
+  - Multi-context set: per-context pending-list filtering, atomic `contexts[]`
+    slots, NULL-slot guard, and `MOD_AUDIO_FORK_SERVICE_THREADS` capped at 1.
+  - NULL connect-error string streamed into an ostream in the glue.
+- **mod_aws_transcribe — both v0.6.0 deferrals closed, verified against the
+  aws-sdk-cpp source shipped in the build image:**
+  - Shutdown wait is now bounded: if the final outcome is >10s overdue after
+    `Close()`, the worker calls `AWSClient::DisableRequestProcessing()`
+    (public API; fails the in-flight request at the http-client layer), which
+    delivers the error outcome via `OnResponseCallback` and unblocks teardown
+    on dead networks.
+  - The "delete while the SDK unwinds past OnResponseCallback" concern is
+    REFUTED as a bug: `~TranscribeStreamingServiceClient` →
+    `ShutdownSdkClient` waits for `m_operationsProcessed == 0` (each async op
+    holds an RAIICounter through its full unwind) and then resets the
+    executor, whose destructor joins in-flight task threads
+    (`AWSClientAsyncCRTP.h`, `DefaultExecutor.cpp`). Documented at the
+    delete site.
+- The same AudioPipe ports (realloc recovery, allocator mismatch, lws_write,
+  multi-context set, bug-add-failure leak) landed in the
+  `mod_ttsd_transcribe` repo in the same pass.
+
+### Still open (unchanged from v0.6.0, with verdicts)
+- google VAD-path `connect()` on the media thread: **accepted limitation** —
+  a safe fix means redesigning the connect signaling (promise set-once and
+  prebuffer locking both grow new race surfaces) and warrants its own soak
+  cycle; the v0.6.0 keepalive bounds the worst case, and the stall affects
+  only that session's own media processing.
+- Multi-context lws service threads stay capped at 1 everywhere pending a
+  per-context connect-adoption redesign.
+- Live-credential vendor streaming remains unverified (needs real creds).
+
+### Verification
+- **[unit]** `make -C tests coverage`: 9/9 pass, 100% coverage (unchanged units).
+- **[build]** aws + audio_fork rebuilt from the fixed sources and loaded in
+  FreeSWITCH 1.10.12 (Docker, audio_fork added to autoload for the test):
+  `module_exists` = true for all five maintained modules.
+- **[tsan]** `tests/soak` (both AudioPipes) with the ported audio_fork
+  sources: OVERALL PASS, ASan+UBSan+LSan and TSan clean, deepgram reaper
+  200/200. Note: an earlier in-container flakiness investigation showed that
+  manually `load`ing modules into a running containerized FS is unreliable
+  for ANY module (baseline included) — load verification uses the autoload
+  boot path, which is stable.
+
 ## v0.6.0 — 2026-07-02
 
 Full adversarial code review of all four maintained transcribe modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,109 @@ live-credentials soak (see `docs/TESTING.md`).
 
 ---
 
+## v0.6.0 — 2026-07-02
+
+Full adversarial code review of all four maintained transcribe modules
+(~5,300 lines, every source file), one commit per issue: **52 confirmed
+findings fixed across 45 commits** (deepgram 14, aws 10, azure 9, google 9,
+plus 1 cross-module and 2 follow-ups the new soak itself surfaced).
+**[unit] [build] [tsan]**
+
+Highlights by severity (per-issue detail is in the individual commit messages):
+
+- **Crashes / use-after-free:**
+  - aws: a stop racing the async connect deleted the GStreamer while the SDK
+    still held `this`-capturing callbacks (UAF on an SDK thread); a stop during
+    GStreamer construction hung the hangup thread forever (VAD path).
+  - azure: env-var-only auth passed a NULL subscription key to
+    `SpeechConfig::FromSubscription` (`std::string(nullptr)` — segfault on the
+    first start); same for an unauthenticated proxy's NULL username/password;
+    the init-failure path deleted the GStreamer with all six raw-`this` SDK
+    handlers still connected; a throwing `StopContinuousRecognitionAsync().get()`
+    on the detached reaper thread was `std::terminate`.
+  - google: bug-add failure and lost same-bugname start races orphaned the
+    gRPC read thread past session destroy (session-pool UAF); an invalid
+    JWT key in the `GOOGLE_APPLICATION_CREDENTIALS` channel variable
+    dereferenced a null credentials pointer; a non-string hints phrase
+    crashed protobuf `set_value`.
+  - deepgram: a NULL lws connect-error string was streamed into an
+    ostringstream on the shared lws service thread; a stereo resample could
+    overflow the send buffer (capacity math ignored channels — same fix in
+    aws/azure/google's declared capacities); `finish()` racing the WS
+    handshake leaked the pipe, thread, and socket forever (ttsd v0.3.0 port);
+    media-bug-add failure leaked a connecting AudioPipe (same fix in azure).
+- **gRPC/lws API contract:** google's `writesDone()` TOCTOU double half-close;
+  `Finish()` unserialized against concurrent `Write()`; writes after
+  half-close. deepgram's `lws_write` failure hidden by a signed/unsigned
+  comparison; cross-context `lws_callback_on_writable` calls with >1 service
+  thread (and, found by this release's new soak: an unsynchronized
+  `contexts[]` publish and a cross-context connect-adoption race — service
+  threads are now capped at 1, the default and production configuration,
+  until adoption is per-context).
+- **Silent failure / audio loss:** google surfaced only OUT_OF_RANGE stream
+  failures — bad credentials/UNAVAILABLE/etc. produced silence (now evented);
+  azure's unsolicited SessionStopped and push-stream write failures were
+  invisible to the consumer (now evented via the existing error subclass);
+  aws's prebuffer drain sent only the first half of every chunk on resampled
+  calls; pre-connect audio was dropped wholesale for non-320-multiple frames
+  in aws/azure/google (30ms ptime, resampler output); stereo audio was sent
+  at half its bytes (aws/google) or resampled as mono (aws/azure); deepgram's
+  empty-transcript filter could discard payloads containing real content.
+- **Hangs:** google had no deadline/keepalive anywhere — a silent network
+  partition stalled hangup for the TCP failure-detection duration (HTTP/2
+  keepalive added, 60s/20s, active calls only); aws's worker held its mutex
+  across blocking `WriteAudioEvent` calls, stalling the FS media thread under
+  back-pressure and making the v0.4.0 bounded-deque cap unreachable.
+- **Consistency/robustness:** bugname key-truncation orphans (aws/azure/google
+  — over-length names now rejected at the API); deepgram stop cleared the
+  wrong channel-private key and never populated the event `media-bugname`
+  header; connect-transition frame reordering/stranding (aws/azure); worker
+  thread exception guards (aws); event-subclass reserve/free (aws);
+  NULL-`%s` log arguments and deref-before-NULL-check cleanups (all four).
+
+Event subclass names and event-body JSON shapes are unchanged throughout;
+the only consumer-visible event changes are additive (previously-missing
+error events, and deepgram's `media-bugname` header now carrying the real
+bug name instead of an empty string).
+
+- **Tests:** `tests/soak` now also soaks the deepgram AudioPipe (ASan+UBSan +
+  TSan; TLS-only dialer, so it exercises the connect-fail/teardown/reaper
+  surfaces — the receive-path code is byte-identical to the
+  mod_ttsd_transcribe AudioPipe, whose own soak covers it end-to-end over
+  plain ws). lws-internal logging races are suppressed via `tsan.supp`
+  (library-only frames; module frames are never suppressed).
+
+### Deferred (recorded, not fixed)
+- aws: the shutdown wait for the SDK's final response is unbounded on a dead
+  network (no safe timeout without SDK-internal verification), and
+  `m_finished` is set inside `OnResponseCallback` before the SDK's async
+  frame fully unwinds — whether the post-callback unwind touches the client
+  is SDK-internal (needs aws-sdk-cpp source review or a live-creds TSan soak).
+- google: the VAD-path `connect()` still blocks the FS media thread on
+  network I/O under `cb->mutex` (structural; keepalive bounds the worst case).
+- Multi-context lws service threads stay capped at 1 pending a per-context
+  connect-adoption redesign (also applies to the mod_audio_fork /
+  mod_ttsd_transcribe lineage — not yet ported there).
+
+### Verification
+- **[unit]** `make -C tests coverage`: 9/9 host tests pass, 100% line coverage
+  of the FS-independent units (`base64.hpp`, `simple_buffer.h` — the latter
+  unchanged by these fixes).
+- **[build]** All four modules rebuilt from the fixed sources with the exact
+  callBroadcast-installer recipes against FreeSWITCH 1.10.12 in Docker
+  (aws-sdk-cpp static stack, Speech SDK 1.49.0, googleapis gens):
+  compile + link clean, `module_exists` = true for all four, 5 transcribe
+  APIs registered. The only warning is a pre-existing `speaker_tag`
+  deprecation in inherited google code.
+- **[tsan]** `tests/soak` (both AudioPipes, ASan+UBSan+LSan and TSan builds):
+  OVERALL PASS; deepgram reaper completion 200/200 in both builds; 0 TSan
+  warnings across 5 additional stress runs (300 iterations × 6 workers).
+  The soak itself found two real races during this release (fixed above:
+  `contexts[]` publish; capped multi-context mode).
+- **Not verified here:** live-credential vendor streaming (deepgram/google/
+  aws/azure runtime transcription needs real credentials + audio — see
+  `docs/TESTING.md`); the FS glue under concurrent live calls.
+
 ## v0.5.2 — 2026-06-28 (`7551c4b`, `0925fe1`)
 AudioPipe teardown use-after-free fix (`mod_audio_fork`, `mod_deepgram_transcribe`).
 **[build] [tsan]**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,115 @@
+# Changelog
+
+Changes since VoiceTel took over maintenance of this fork (baseline:
+`aa07b27`, "README: mark fork as voicetel-maintained").
+
+Scope of maintenance: the four streaming speech-to-text modules used by
+callBroadcast — `mod_deepgram_transcribe`, `mod_google_transcribe`,
+`mod_aws_transcribe`, `mod_azure_transcribe` — plus `mod_audio_fork`. All other
+modules are inherited from upstream and unmaintained.
+
+Verification legend: **[unit]** host unit tests + ASan/UBSan, **[build]** compiles/
+links/loads in FreeSWITCH 1.10.12, **[tsan]** ThreadSanitizer-clean via
+`tests/soak`. The vendor-SDK streaming paths and the FS glue still require a
+live-credentials soak (see `docs/TESTING.md`).
+
+---
+
+## v0.5.1 — 2026-06-25 (`65f2a45`)
+Docs only.
+- Added `docs/TESTING.md`: the reproducible 5-layer testing methodology, gotchas,
+  a new-module decision tree, and an honesty checklist. README links the testing
+  layers.
+
+## v0.5.0 — 2026-06-25 (`9aac6db`, `67c2b9c`)
+Full data-race audit of every maintained module, plus a race-free shutdown and an
+ASan/TSan soak harness. **[unit] [build] [tsan]**
+
+- **Cross-thread struct flags were plain `int`/bitfields read on the media thread
+  while written by another thread** (`got_end_of_utterance` in google;
+  `audio_paused`/`graceful_shutdown` in mod_audio_fork) → made atomic via an
+  ABI-safe `#ifdef __cplusplus std::atomic` pattern (C view/struct layout
+  unchanged). A `cb->mutex` guard was rejected for `got_end_of_utterance` because
+  it deadlocks cleanup (holds the mutex across `thread_join`) vs the read thread.
+- **Cross-thread stream pointers published without synchronization**
+  (`cb->streamer` in google/aws) → `std::atomic<void*>`.
+- **google: `Write` (media thread) and `WritesDone` (read thread) on the same gRPC
+  stream were not serialized** (undefined behavior) → guarded by a dedicated write
+  mutex.
+- **google: `google_speech_frame` loaded `cb->streamer` before the trylock and
+  dereferenced the stale local under the lock** → use-after-free on the do_stop
+  path (cleanup deletes+nulls the stream under the mutex). Now re-reads under the
+  lock and gates the read loop on it.
+- **aws/azure: the pre-connect prebuffer (`SimpleBuffer`) was added-to on the media
+  thread and drained on an SDK thread without synchronization** → guarded by a
+  dedicated buffer mutex (one-way lock order, non-recursive-safe, no deadlock).
+- **mod_audio_fork: the `playout` temp-file list was appended on the lws thread and
+  freed on the API thread** → append now under `tech_pvt->mutex` (matches the free
+  loop).
+- **AudioPipe shutdown was racy** (`deinitialize`): service threads were detached,
+  the service loop read a `std::map` (`stopFlags[this_id]`) every iteration without
+  the mutex, and only one of N threads was stopped before contexts were destroyed.
+  Found by ThreadSanitizer. → replaced with an atomic stop flag + joinable threads;
+  `deinitialize` now signals stop, `lws_cancel_service`s each context, **joins**
+  the threads, then destroys the contexts.
+- **Benign global counters** (`idxCallCount`, `AudioPipe::nchild`) raced on
+  concurrent `start` → made atomic.
+- Added `tests/soak/`: a Dockerized ASan+TSan concurrency soak of the real
+  `AudioPipe` (200×4 iterations: connect / stream / far-end drop / graceful stop /
+  rapid restart / connect-fail / teardown / shutdown) — result: ASan + TSan clean.
+
+## v0.4.0 — 2026-06-25 (`e6239b4`; tooling `eaedb7d`)
+The concurrency/lifecycle items flagged-but-deferred in the v0.1.0 review.
+**[unit] [build]**
+- **deepgram: detached `reaper` thread captured `tech_pvt` and read it after the
+  session could be freed** (use-after-free); **`deinitialize`-era `switch_mutex_destroy`
+  of a session-pool-owned mutex** (double cleanup) → capture `sessionId`/`id` by
+  value; stop destroying the pool mutex; close-promise signalled on every terminal
+  path so the reaper can't hang.
+- **aws: `m_pStream` published on the SDK IO thread without the mutex** → atomic;
+  **unbounded audio deque under back-pressure** → bounded with drop-oldest
+  (`AWS_TRANSCRIBE_MAX_BUFFERED_FRAMES`, default ~10s) [behavior-changing];
+  **thread + GStreamer leaked when `switch_core_media_bug_add` failed after init**
+  → teardown on that path; **hot path:** per-frame heap alloc moved out of the lock.
+- **google: gRPC write-side `Write`/`WritesDone` not serialized** → write mutex
+  (refined in v0.5.0).
+- **azure: SDK callbacks could fire on a GStreamer being torn down** → `DisconnectAll()`
+  every recognizer signal before `StopContinuousRecognitionAsync().get()`.
+- Tooling: `make -C tests sanitize` (ASan/UBSan) + `tests/SANITIZERS.md`.
+
+## v0.3.0 — 2026-06-24 (`fdf245a`)
+`mod_audio_fork` AudioPipe use-after-free rework. **[build]**, since soak-tested live.
+- **The AudioPipe was `delete`d inside the lws CLOSED callback while a media-bug
+  thread could still hold it, and `eventCallback` cleared `pAudioPipe` without the
+  mutex** → genuine use-after-free on far-end drop during an active call. Replaced
+  with promise-based close signalling (`setClosed`/`waitForClose`) and a reaper that
+  deletes the pipe only after the media bug is removed and the socket close is
+  signalled. (`f84d7dc`: dropped the README "hardening in progress" caveat after the
+  live soak confirmed it.)
+
+## v0.2.0 — 2026-06-24 (`15861ee`; `0c8d0e5`)
+`mod_audio_fork` safe-tier hardening (ported from its `mod_deepgram_transcribe`
+descendant). **[build]**
+- LWS_PRE ring-buffer reset (was reset to `0`, shipping header bytes / corrupting
+  audio on overrun); NULL-`ap` dereferences in log branches; stereo resampler byte
+  math; `lws_logger` level mapping; atomic connection state; auth fail-closed (was
+  silently connecting unauthenticated on gen failure); VLA→heap for a
+  server-controlled length; cJSON/URI NUL guards; RAII guards. (`0c8d0e5`: README
+  marks `mod_audio_fork` maintained.)
+
+## v0.1.0 — 2026-06-24 (`55ad536`; `f21b8de`; `e2b3298`)
+First tagged release: the four transcribe modules. **[unit] [build]**
+- **Memory-safety / input-validation:** `simple_buffer.h` (shared, byte-identical)
+  read via the *write* cursor and underflowed `getNextChunk()` → separate read
+  cursor + empty guard; `memset(cb, sizeof(cb), 0)` (zeroed nothing) in aws/azure
+  → `memset(cb, 0, sizeof(*cb))`; `argv[1]` dereferenced before the `argc` check in
+  all four API handlers (NULL-deref crash) → guarded; unterminated credential
+  `strncpy`; deepgram LWS_PRE reset, NULL-`ap` logs, api-key bound, resampler math,
+  `&version=`; defensive `responseHandler` (no event-subclass renames — callBroadcast
+  consumes those).
+- **Tier 1+2 optimizations:** aws transcript JSON via cJSON (correct escaping,
+  identical shape); google `const&` protobuf loop vars + lazy VAD buffer; azure
+  `640`-vs-`320` prebuffer fix; INFO→DEBUG transcript logging; RAII session/mutex
+  guards; magic-number naming.
+- Added `tests/` host unit harness (`base64`, `SimpleBuffer`, 100% line coverage).
+- (`e2b3298`: README rewritten to state the maintained scope.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ live-credentials soak (see `docs/TESTING.md`).
 
 ---
 
+## v0.6.2 — 2026-07-02
+Docs only.
+- `docs/TESTING.md`: the Layer-3 load gate no longer recommends `fs_cli -x
+  "load mod_x"` into a running containerized FS — measured during the v0.6.1
+  work, that path intermittently segfaults FS for ANY module (an unmodified
+  baseline died on manual load in 4/5 trials) and produces convincing false
+  FAILs. Gate via the autoload boot path (modules.conf.xml) instead, with the
+  retry-wrapped boot+load sequence as the fallback when manual load is
+  unavoidable.
+
 ## v0.6.1 — 2026-07-02
 
 Completes the v0.6.0 review: the shared-lineage AudioPipe fixes ported to

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-**Please note: This repo is no longer being actively maintained.**
+**This fork (voicetel/drachtio-freeswitch-modules) is actively maintained by VoiceTel as of 2026-05.**
 
-**For those interested in similar modules, please refer to [this repo](https://github.com/jambonz/freeswitch-modules)  which is offered under a different (dual-licensing) scheme:**
+The upstream drachtio repo is in preservation mode. We picked up active
+maintenance for the modules we ship in production (primarily
+`mod_audio_fork`); patches against this fork are accepted via the
+voicetel/drachtio-freeswitch-modules tracker. Pull requests against
+upstream drachtio/drachtio-freeswitch-modules will not be answered.
 
-- **AGLP-3 for general usage.**
+For an alternative that is also actively maintained but under a different
+(dual-licensing) scheme, see [jambonz/freeswitch-modules](https://github.com/jambonz/freeswitch-modules):
+
+- **AGPL-3 for general usage.**
 - **MIT for use with [jambonz](https://jambonz.org) installs <ins>only</ins>.**
 
 # drachtio-freeswitch-modules

--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ L16 audio to the vendor, returning transcripts as FreeSWITCH custom events:
 
 **Audio streaming** — [`mod_audio_fork`](modules/mod_audio_fork/README.md):
 streams L16 audio over WebSockets (libwebsockets) to your own server, with
-optional playback injection back into the call. Recently hardened (memory
-safety, thread-safety, input validation), verified to build and load in
-FreeSWITCH 1.10.12. **Caveat:** a remaining AudioPipe lifecycle / use-after-free
-rework is still pending, so treat it as actively-being-hardened rather than
-finished.
+optional playback injection back into the call. Hardened for memory safety,
+thread-safety, input validation, and correct connection lifecycle (no
+use-after-free on disconnect); verified to build and load in FreeSWITCH 1.10.12.
 
 ## Everything else
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 A fork of [drachtio/drachtio-freeswitch-modules](https://github.com/drachtio/drachtio-freeswitch-modules).
 
-**VoiceTel actively maintains only a small subset of this repository** — the
-streaming speech-to-text modules and `mod_audio_fork`, which we ship in
-production. Everything else is inherited from upstream and kept **as-is,
-unmaintained**.
+**VoiceTel actively maintains only a small subset of this repository** — the four
+streaming speech-to-text modules, which we ship in production, plus
+`mod_audio_fork`, which we maintain but do **not** ship or use ourselves.
+Everything else is inherited from upstream and kept **as-is, unmaintained**.
 
 See **[CHANGELOG.md](CHANGELOG.md)** for everything changed since VoiceTel took
 over maintenance, and **[docs/TESTING.md](docs/TESTING.md)** for how it's tested.
@@ -26,9 +26,11 @@ L16 audio to the vendor, returning transcripts as FreeSWITCH custom events:
 
 **Audio streaming** — [`mod_audio_fork`](modules/mod_audio_fork/README.md):
 streams L16 audio over WebSockets (libwebsockets) to your own server, with
-optional playback injection back into the call. Hardened for memory safety,
-thread-safety, input validation, and correct connection lifecycle (no
-use-after-free on disconnect); verified to build and load in FreeSWITCH 1.10.12.
+optional playback injection back into the call. **VoiceTel maintains this module
+but does not ship or use it** (our production audio streaming uses a separate
+module). Hardened for memory safety, thread-safety, input validation, and correct
+connection lifecycle (no use-after-free on disconnect); verified to build and
+load in FreeSWITCH 1.10.12.
 
 ## Everything else
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,17 @@
 
 A fork of [drachtio/drachtio-freeswitch-modules](https://github.com/drachtio/drachtio-freeswitch-modules).
 
-**VoiceTel actively maintains only a small subset of this repository** — the four
-streaming speech-to-text modules we ship in production. Everything else is
-inherited from upstream and kept **as-is, unmaintained**.
+**VoiceTel actively maintains only a small subset of this repository** — the
+streaming speech-to-text modules and `mod_audio_fork`, which we ship in
+production. Everything else is inherited from upstream and kept **as-is,
+unmaintained**.
 
 ## Maintained modules
 
-These are the only modules VoiceTel patches, builds, and verifies:
+These are the only modules VoiceTel patches, builds, and verifies.
+
+**Streaming speech-to-text** — each attaches a media bug to a channel and streams
+L16 audio to the vendor, returning transcripts as FreeSWITCH custom events:
 
 | Module | Transport | Vendor |
 |---|---|---|
@@ -17,24 +21,29 @@ These are the only modules VoiceTel patches, builds, and verifies:
 | [`mod_aws_transcribe`](modules/mod_aws_transcribe/README.md) | HTTP/2 event-stream | AWS Transcribe streaming |
 | [`mod_azure_transcribe`](modules/mod_azure_transcribe/README.md) | push-stream | Microsoft Cognitive Services Speech |
 
-Each attaches a media bug to a channel and streams L16 audio to the vendor,
-returning transcripts as FreeSWITCH custom events.
+**Audio streaming** — [`mod_audio_fork`](modules/mod_audio_fork/README.md):
+streams L16 audio over WebSockets (libwebsockets) to your own server, with
+optional playback injection back into the call. Recently hardened (memory
+safety, thread-safety, input validation), verified to build and load in
+FreeSWITCH 1.10.12. **Caveat:** a remaining AudioPipe lifecycle / use-after-free
+rework is still pending, so treat it as actively-being-hardened rather than
+finished.
 
 ## Everything else
 
-All other modules in `modules/` (including `mod_audio_fork`, `mod_google_tts`,
-`mod_dialogflow`, `mod_aws_lex`, and the rest) are inherited from upstream and
-are **not maintained here**. They are left untouched for reference; we do not
-build, test, or fix them.
+All other modules in `modules/` (`mod_google_tts`, `mod_dialogflow`,
+`mod_aws_lex`, and the rest) are inherited from upstream and are **not maintained
+here**. They are left untouched for reference; we do not build, test, or fix them.
 
 ## Building
 
 These are FreeSWITCH loadable modules — they build **inside the FreeSWITCH
 source tree**, not standalone. There is no top-level build in this repo.
 
-The four maintained modules are verified to compile, link, and load in
-**FreeSWITCH 1.10.12**. Each needs its vendor SDK present at build time:
+The maintained modules are verified to compile, link, and load in
+**FreeSWITCH 1.10.12**. Each needs its library/SDK present at build time:
 
+- `mod_audio_fork` — libwebsockets
 - `mod_deepgram_transcribe` — libwebsockets
 - `mod_google_transcribe` — gRPC + the Google Cloud Speech protobuf stubs
 - `mod_aws_transcribe` — AWS SDK for C++ (`transcribestreaming`)

--- a/README.md
+++ b/README.md
@@ -1,53 +1,68 @@
-**This fork (voicetel/drachtio-freeswitch-modules) is actively maintained by VoiceTel as of 2026-05.**
+# drachtio-freeswitch-modules (VoiceTel fork)
 
-The upstream drachtio repo is in preservation mode. We picked up active
-maintenance for the modules we ship in production (primarily
-`mod_audio_fork`); patches against this fork are accepted via the
-voicetel/drachtio-freeswitch-modules tracker. Pull requests against
-upstream drachtio/drachtio-freeswitch-modules will not be answered.
+A fork of [drachtio/drachtio-freeswitch-modules](https://github.com/drachtio/drachtio-freeswitch-modules).
 
-For an alternative that is also actively maintained but under a different
-(dual-licensing) scheme, see [jambonz/freeswitch-modules](https://github.com/jambonz/freeswitch-modules):
+**VoiceTel actively maintains only a small subset of this repository** — the four
+streaming speech-to-text modules we ship in production. Everything else is
+inherited from upstream and kept **as-is, unmaintained**.
 
-- **AGPL-3 for general usage.**
-- **MIT for use with [jambonz](https://jambonz.org) installs <ins>only</ins>.**
+## Maintained modules
 
-# drachtio-freeswitch-modules
+These are the only modules VoiceTel patches, builds, and verifies:
 
-An open-source collection of freeswitch modules, primarily built for for use with [drachtio](https://drachtio.org) applications utilizing [drachtio-fsrmf](https://www.npmjs.com/package/drachtio-fsmrf), but generally usable and useful with generic freeswitch applications.  These modules have beeen tested with Freeswitch version 1.8.
+| Module | Transport | Vendor |
+|---|---|---|
+| [`mod_deepgram_transcribe`](modules/mod_deepgram_transcribe/README.md) | libwebsockets | Deepgram |
+| [`mod_google_transcribe`](modules/mod_google_transcribe/README.md) | gRPC | Google Cloud Speech-to-Text |
+| [`mod_aws_transcribe`](modules/mod_aws_transcribe/README.md) | HTTP/2 event-stream | AWS Transcribe streaming |
+| [`mod_azure_transcribe`](modules/mod_azure_transcribe/README.md) | push-stream | Microsoft Cognitive Services Speech |
 
-#### [mod_audio_fork](modules/mod_audio_fork/README.md)
-A Freeswitch module that attaches a bug to a media server endpoint and streams L16 audio via websockets to a remote server. The audio is never stored to disk locally on the media server, making it ideal for "no data at rest" type of applications.  This module also supports receiving media from the server to play back to the caller, enabling the creation of full-fledged IVR or dialog-type applications.
+Each attaches a media bug to a channel and streams L16 audio to the vendor,
+returning transcripts as FreeSWITCH custom events.
 
-#### [mod_google_tts](modules/mod_google_tts/README.md)
-A tts provider module that integrates with Google Cloud Text-to-Speech API and integrates into freeswitch's TTS framework (i.e., usable with the mod_dptools 'speak' application)
+## Everything else
 
-#### [mod_google_transcribe](modules/mod_google_transcribe/README.md)
-Adds a Freeswitch API call to start (or stop) real-time transcription on a Freeswitch channel using Google Cloud Speech-to-Text API.
+All other modules in `modules/` (including `mod_audio_fork`, `mod_google_tts`,
+`mod_dialogflow`, `mod_aws_lex`, and the rest) are inherited from upstream and
+are **not maintained here**. They are left untouched for reference; we do not
+build, test, or fix them.
 
-#### [mod_dialogflow](modules/mod_dialogflow/README.md)
-Adds a Freeswitch API to start a Google Dialogflow agent on a Freeswitch channel.
+## Building
 
-#### [mod_aws_lex](modules/mod_aws_lex/README.md)
-Adds Freeswitch APIs call to integrate with aws lex v2 apis.
+These are FreeSWITCH loadable modules — they build **inside the FreeSWITCH
+source tree**, not standalone. There is no top-level build in this repo.
 
-#### [mod_aws_transcribe](modules/mod_aws_transcribe/README.md)
-Adds a Freeswitch API call to start (or stop) real-time transcription on a Freeswitch channel using AWS streaming transcription (HTTP/2 based).
+The four maintained modules are verified to compile, link, and load in
+**FreeSWITCH 1.10.12**. Each needs its vendor SDK present at build time:
 
+- `mod_deepgram_transcribe` — libwebsockets
+- `mod_google_transcribe` — gRPC + the Google Cloud Speech protobuf stubs
+- `mod_aws_transcribe` — AWS SDK for C++ (`transcribestreaming`)
+- `mod_azure_transcribe` — Microsoft Cognitive Services Speech SDK
 
-# Installation
+At runtime each module reads its credentials from channel variables or
+environment (see the module's own README).
 
-These modules have dependencies that require a custom version of freeswitch to be built that has support for [grpc](https://github.com/grpc/grpc) (if any of the google modules are built) and [libwebsockets](https://libwebsockets.org). Specifically, mod_google_tts, mod_google_transcribe and mod_dialogflow require grpc, and mod_audio_fork requires libwebsockets.
+## Tests
 
-#### Building from source
-[This ansible role](https://github.com/davehorton/ansible-role-fsmrf) can be used to build a freeswitch 1.8 with support for these modules.  Even if you don't want to use ansible for some reason, the [task files](https://github.com/davehorton/ansible-role-fsmrf/tree/master/tasks), and the [patchfiles](https://github.com/davehorton/ansible-role-fsmrf/tree/master/files) should let you work out how to build it yourself manually or through your preferred automation (but why not just use ansible!)
+`tests/` contains host-side unit tests for the FreeSWITCH-independent logic that
+can be exercised without the full FreeSWITCH tree or the vendor SDKs:
 
-> Note: that ansible role assumes you are building on Debian 9 (stretch).
+```sh
+make -C tests          # build + run
+make -C tests coverage # + gcov line coverage
+```
 
-#### Using docker
+Module glue that depends on the FreeSWITCH runtime and live vendor streams is
+not host-testable and is verified by building/loading inside FreeSWITCH.
 
-`docker pull drachtio/drachtio-freeswitch-mrf:v1.10.1-full` to get a docker image containing all of the above modules with the exception of mod_aws_transcribe.
+## Contributing
 
-## Configuring
+Patches to the **maintained modules** are accepted via the
+[voicetel/drachtio-freeswitch-modules](https://github.com/voicetel/drachtio-freeswitch-modules)
+tracker. Issues or PRs against the unmaintained modules, or against upstream
+drachtio, will not be actioned here.
 
-The three modules that access google services (mod_google_tts, mod_google_transcribe, and mod_dialogflow) require a JSON service key file to be installed on the Freeswitch server, and the environment variable named "GOOGLE_APPLICATION_CREDENTIALS" must point to that file location.
+## License
+
+See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -52,16 +52,30 @@ environment (see the module's own README).
 
 ## Tests
 
-`tests/` contains host-side unit tests for the FreeSWITCH-independent logic that
-can be exercised without the full FreeSWITCH tree or the vendor SDKs:
+Testing is layered (see **[docs/TESTING.md](docs/TESTING.md)** for the full,
+reproducible methodology and how to apply it to other modules):
 
-```sh
-make -C tests          # build + run
-make -C tests coverage # + gcov line coverage
-```
+- **Host unit tests** for FreeSWITCH-independent logic (`base64`, `SimpleBuffer`):
 
-Module glue that depends on the FreeSWITCH runtime and live vendor streams is
-not host-testable and is verified by building/loading inside FreeSWITCH.
+  ```sh
+  make -C tests            # build + run
+  make -C tests coverage   # + gcov line coverage
+  make -C tests sanitize   # + AddressSanitizer/UBSan
+  ```
+
+- **Concurrency soak** of the real `AudioPipe` WebSocket transport under
+  AddressSanitizer + ThreadSanitizer ([tests/soak/](tests/soak/README.md)):
+
+  ```sh
+  docker build -f tests/soak/Dockerfile -t audiopipe-soak .
+  docker run --rm --security-opt seccomp=unconfined audiopipe-soak
+  ```
+
+- **Compile/link/load** of every module is verified inside a FreeSWITCH build.
+
+Module glue that depends on the FreeSWITCH runtime, and the vendor-SDK streaming
+paths, are not host-testable — they need a live-credentials soak
+([tests/SANITIZERS.md](tests/SANITIZERS.md)).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ streaming speech-to-text modules and `mod_audio_fork`, which we ship in
 production. Everything else is inherited from upstream and kept **as-is,
 unmaintained**.
 
+See **[CHANGELOG.md](CHANGELOG.md)** for everything changed since VoiceTel took
+over maintenance, and **[docs/TESTING.md](docs/TESTING.md)** for how it's tested.
+
 ## Maintained modules
 
 These are the only modules VoiceTel patches, builds, and verifies.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,235 @@
+# FreeSWITCH module testing playbook
+
+How the `drachtio-freeswitch-modules` STT/audio modules were tested, written so the
+same process can be applied to other modules. Covers four independent layers and,
+at the end, a decision tree for a new module.
+
+Reality up front: these modules build **only inside the FreeSWITCH source tree**
+(autotools + `libfreeswitch` + vendor SDKs). There is no standalone build. So
+"testing" is layered, and each layer catches a different class of problem. Be
+honest about which layer proves what:
+
+| Layer | What it proves | What it does NOT prove |
+|---|---|---|
+| 1. Static analysis | suspicious patterns, some memory/UB bugs | no data races; many false positives without FS headers |
+| 2. Host unit tests (+ASan/UBSan +coverage) | pure logic correct, memory-safe, covered | nothing that needs FS runtime or vendor SDKs |
+| 3. Docker FS build + load smoke test | compiles, links, `dlopen`s with all symbols resolved | runtime behavior; concurrency |
+| 4. Standalone ASan/TSan concurrency soak | no data races / UAF / leaks in transport+lifecycle | the FS glue; the vendor-SDK paths |
+| (5. live-credential soak) | end-to-end behavior + full concurrency | — (this one needs your creds + calls) |
+
+Layers 1–4 are all doable on a dev box / in Docker. Layer 5 needs real vendor
+credentials and live calls — it can't be faithfully mocked for SDK-based vendors
+(AWS/Azure) and is the only thing that confirms "zero races" under production load.
+
+---
+
+## Layer 1 — Static analysis (cheap, run first)
+
+cppcheck tolerates missing FS headers; clang-tidy mostly needs them (run it inside
+the FS tree — see Layer 3 — with the FS include paths).
+
+```sh
+# per module, C++ mode, suppress the unavoidable cross-module / missing-include noise
+cppcheck --language=c++ --enable=warning,performance,portability --inline-suppr --quiet \
+  --suppress=missingInclude --suppress=missingIncludeSystem --suppress=unknownMacro \
+  --suppress=ctuOneDefinitionRuleViolation \
+  modules/<mod>/*.c modules/<mod>/*.cpp modules/<mod>/*.h modules/<mod>/*.hpp
+```
+
+cppcheck does NOT detect data races — don't rely on it for concurrency. Treat its
+output as advisory; triage real findings (unchecked malloc, uninit members, etc.).
+
+---
+
+## Layer 2 — Host unit tests + ASan/UBSan + coverage
+
+Only logic with **no** FreeSWITCH runtime / vendor-SDK / network dependency is
+host-testable (e.g. `base64.hpp`, `SimpleBuffer` in `simple_buffer.h`). Do not mock
+the FS core to fake coverage — test the genuinely-pure pieces and say plainly what
+isn't host-testable.
+
+In this repo: `tests/` (a tiny header-only harness `test_util.h` + `test_*.cpp`,
+a `Makefile`).
+
+```sh
+make -C tests            # build + run
+make -C tests coverage   # + gcov; prints HOST_COVERAGE=<pct>%
+make -C tests sanitize   # build + run under AddressSanitizer + UndefinedBehaviorSanitizer
+```
+
+The `sanitize` target compiles the same units with `-fsanitize=address,undefined
+-fno-omit-frame-pointer` and runs them — real runtime memory-safety/UB checking of
+that logic. To add a unit: write `tests/test_<x>.cpp` using `test_util.h`
+(`TEST(name){ CHECK(...); CHECK_EQ(a,b); }`), point its `-I` at the module that owns
+the header, and add it to `TESTS`/`COV_SRCS` in `tests/Makefile`.
+
+---
+
+## Layer 3 — Docker FS build + load smoke test (authoritative compile/link/load)
+
+This proves the module compiles, links, and `dlopen`s into a running FreeSWITCH
+with all `switch_*` symbols resolved (and its API verb registers). It reuses
+callBroadcast's known-good FreeSWITCH installer with the module branch injected.
+
+### Pattern
+1. Build context in scratch (NOT the repo): copy `callBroadcast/freeswitch/`, and
+   `git clone --branch <branch> <repo>` into it.
+2. Dockerfile: `FROM debian:trixie`, install build deps, run the installer with the
+   branch wired in, then a smoke test.
+3. Inject the branch via the installer's env knobs:
+   `ENV DRACHTIO_REPO=/src/drachtio-src DRACHTIO_REF=<branch>`.
+
+### Gotchas that each cost a failed build (bake these in)
+- **`libpcre2-dev`** — FS 1.10.12 `configure` hard-requires `libpcre2-8.pc`, which
+  the installer only gets transitively. Add `libpcre2-dev` to the Dockerfile apt
+  line or configure aborts. (This is a latent fragility in callBroadcast's
+  installer too — it should add it to its apt list.)
+- **`JOBS=2`** — the installer uses `make -j$(nproc)`; on a 14 GiB host with other
+  processes, `-j20` (and even `-j4`) OOM-kills the FreeSWITCH link (exit 137). Set
+  `ENV JOBS=2` (honored by the installer). Prune stopped containers/dangling images
+  first to free space/RAM.
+- **Private modules** — `mod_audio_stream` / `mod_siprec` come from private repos
+  needing `DEPLOY_REPO_PAT`. In the context copy of the installer, neuter
+  `install_mod_audio_stream` to a no-op and soften the `mod_audio_stream.so` `die`
+  in `verify()` to a `warn`.
+- **`mod_audio_fork` is not built by the installer** (callBroadcast dropped it). Add
+  a Dockerfile `RUN` that compiles it from the staged source with the same recipe
+  the installer uses for the libwebsockets-based modules (gcc/g++ `-c` each source
+  with `-I$FS_SRC/src/include -I$FS_SRC/libs/libteletone/src -I/usr/include/uuid` +
+  FS cflags, then `g++ -shared ... $(pkg-config --libs libwebsockets) -lstdc++
+  -lpthread`, install to `$PREFIX/lib/freeswitch/mod/`).
+
+Key installer paths inside the image: `PREFIX=/usr/local/freeswitch`,
+`FS_SRC=/usr/local/src/callbroadcast/freeswitch`,
+`FORK_SRC=/usr/local/src/callbroadcast/drachtio-freeswitch-modules`.
+
+### The smoke test (the load gate) — do NOT parse `load` output
+`fs_cli -x "load mod_x"` prints `+OK Reloading XML` *before* the real result, which
+masks `-ERR module load file routine returned an error`. Use `module_exists`
+(authoritative): a module whose `_load` returned error will not exist.
+
+```sh
+/usr/local/freeswitch/bin/freeswitch -nonat -nc -nonatmap -nf >/tmp/fs.log 2>&1 &
+sleep 12
+for m in <modules that autoload>; do
+  r=$(fs_cli -x "module_exists $m" | tr -d '[:space:]')
+  [ "$r" = true ] && echo "OK: $m" || { echo "FAIL: $m=$r"; tail -150 /tmp/fs.log; exit 1; }
+done
+# for a non-autoloaded module: load it, then require module_exists==true AND its API verb:
+fs_cli -x "load mod_audio_fork" >/dev/null; sleep 2
+[ "$(fs_cli -x 'module_exists mod_audio_fork'|tr -d '[:space:]')" = true ] && \
+[ "$(fs_cli -x 'show api'|grep -c '^uuid_audio_fork,')" -ge 1 ] && echo OK || { echo FAIL; exit 1; }
+```
+
+Build is ~15–30 min at `JOBS=2`; the image is ~3.5 GB — delete it and the scratch
+context afterward. This catches real bugs: it caught a duplicate `m_gracefulShutdown`
+initializer and a fatal double-reservation of a shared event subclass
+(`jambonz_transcribe::error`) that made the 2nd/3rd module's `_load` fail.
+
+---
+
+## Layer 4 — Standalone ASan/TSan concurrency soak (the high-value one)
+
+This is the only way to get real **ThreadSanitizer** results here. The trick that
+makes it possible: the WebSocket transport class (`AudioPipe` in mod_audio_fork /
+the deepgram lineage) depends only on **libwebsockets + the C++ stdlib — zero
+`switch_*` symbols**. So it can be compiled and driven *without FreeSWITCH*, which
+means you control the whole binary and TSan works.
+
+Check first whether the concurrency-bearing code is FS-free:
+```sh
+grep -oE 'switch_[a-z_]+' modules/<mod>/<file>.cpp | sort -u   # empty -> harness-able standalone
+```
+
+The harness (`tests/soak/`) builds the **real** module source twice — once with
+`-fsanitize=address,undefined` and once with `-fsanitize=thread` — and drives,
+concurrently in a loop:
+- the real lws service thread (started by `AudioPipe::initialize`),
+- a "media thread" that writes audio into the ring buffer exactly like the media-bug
+  callback does,
+- the teardown/reaper (`close` -> `waitForClose` -> delete via `shared_ptr`),
+against a mock WebSocket server, cycling the scenario matrix:
+**graceful stop · hangup-mid-stream · far-end drop · rapid restart · connect-fail.**
+
+```sh
+# build context = repo root so it uses the LIVE module source
+docker build -f tests/soak/Dockerfile -t audiopipe-soak .
+docker run --rm --security-opt seccomp=unconfined audiopipe-soak     # OVERALL: PASS == both sanitizers clean
+```
+
+### Soak gotchas
+- **TSan "unexpected memory mapping"** on recent kernels (ASLR entropy too high):
+  run the binary under `setarch -R` (disables ASLR). Needs `util-linux` +
+  `--security-opt seccomp=unconfined` so the `personality()` syscall is allowed.
+- **TSan can't be `LD_PRELOAD`ed** (unlike ASan) — the binary must be *built* with
+  `-fsanitize=thread`. That's why the standalone harness exists: instrumenting all
+  of FreeSWITCH with TSan is impractical, but the FS-free transport class is easy.
+- **Mirror the real call ordering in the harness or you'll chase phantom bugs.**
+  `initialize()` spawns the service thread that creates the lws context
+  *asynchronously*; in FreeSWITCH the first `connect()` is seconds later, so the
+  harness must `sleep` after `initialize()` before connecting (otherwise
+  `connect()` dereferences a NULL `contexts[]` — a harness bug, not a module bug).
+- **WebSocket subprotocol** — the libwebsockets client offers a subprotocol
+  (`audio.drachtio.org`); the mock server (python `websockets`) must negotiate it:
+  `serve(..., subprotocols=["audio.drachtio.org"])`, or the handshake fails.
+- **Classify every sanitizer finding** as a real module bug vs a harness/shutdown
+  artifact before acting. This soak's TSan run found a genuine race — but only in
+  the module-unload `deinitialize()` path (detached threads + an unlocked
+  `std::map` read + destroy-without-join), not the per-call lifecycle. That was a
+  real bug worth fixing; a naive reading would have mislabeled it.
+
+This layer found and we fixed: the `deinitialize()` shutdown race; and it
+*confirmed* the earlier per-call fixes (the AudioPipe use-after-free rework and the
+cross-thread atomics) hold up — ASan + TSan clean across 200 iters × 4 workers.
+
+---
+
+## Layer 5 — Live-credential soak (yours to run)
+
+Real ASan/TSan of the modules' *full* concurrency (media thread × vendor
+SDK/gRPC/ws threads × teardown) needs a real backend, because the vendor threads
+only fire when actually connected:
+- **ws-based (mod_audio_fork, deepgram)** can use a mock ws server (Layer 4 already
+  does the transport; full glue needs FS + a ws sink).
+- **google** speaks gRPC — a mock `StreamingRecognize` server is buildable from the
+  public proto (significant effort).
+- **aws / azure** use the AWS SDK (SigV4 + HTTP/2 + `vnd.amazon.eventstream`) and
+  the MS Speech SDK (proprietary USP-over-wss). These validate TLS/auth/framing
+  against their real backends; a faithful in-container mock is not realistically
+  achievable. Soak them against the vendor sandbox with test credentials.
+
+To build a module with sanitizers inside the FS tree (for Layer 5), append to the
+per-module compile/link in the installer recipe:
+`-fsanitize=address,undefined -fno-omit-frame-pointer -g` (ASan; LD_PRELOAD
+`$(gcc -print-file-name=libasan.so)` into stock FS), or, separately,
+`-fsanitize=thread` (needs FS itself built with TSan to be low-noise). See
+`tests/SANITIZERS.md` for the run setup and the scenario list.
+
+---
+
+## Applying this to a NEW module — decision tree
+
+1. **Static (Layer 1)** — always. cppcheck per module; clang-tidy inside the FS
+   tree if you want analyzer/concurrency checks.
+2. **Pure logic? (Layer 2)** — is there logic with no FS/SDK/network dependency
+   (parsers, buffers, codecs, framing math)? Add host unit tests + run them under
+   `make sanitize`; report coverage. If nothing qualifies, say so.
+3. **Compile/link/load (Layer 3)** — always, before merge. Add the module to the
+   Docker FS build + `module_exists` smoke test. If it's not built by the installer,
+   add a manual compile `RUN` mirroring a sibling with the same deps.
+4. **Concurrency code? (Layer 4)** — does it have its own threads / shared state
+   (a transport class, a worker thread, SDK callbacks)? Run
+   `grep -oE 'switch_[a-z_]+' <file>` — if it's FS-free, build a standalone
+   ASan+TSan harness (copy `tests/soak/` and adapt the driver to that class's API +
+   a matching mock server). If it's NOT FS-free, you're limited to ASan-via-
+   LD_PRELOAD inside FS (Layer 5) — TSan needs the whole-process build.
+5. **End-to-end (Layer 5)** — for production confidence on vendor-SDK paths, soak
+   against the real vendor sandbox with test creds under ASan (and TSan if you can
+   build FS instrumented). This is the only layer that proves "zero races under
+   load"; everything above is necessary but not sufficient for that claim.
+
+### Honesty checklist for any test report
+- Distinguish **compiled/linked/loaded** from **runtime-verified**.
+- "ASan/TSan clean" means *for the scenarios actually exercised* — state them.
+- Name what was NOT covered (glue, vendor SDKs, scenarios not run).
+- A green Docker `module_exists` is load-time only; it is not a behavior test.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -115,11 +115,32 @@ for m in <modules that autoload>; do
   r=$(fs_cli -x "module_exists $m" | tr -d '[:space:]')
   [ "$r" = true ] && echo "OK: $m" || { echo "FAIL: $m=$r"; tail -150 /tmp/fs.log; exit 1; }
 done
-# for a non-autoloaded module: load it, then require module_exists==true AND its API verb:
-fs_cli -x "load mod_audio_fork" >/dev/null; sleep 2
+```
+
+### Non-autoloaded modules: put them ON the autoload path for the gate
+Do NOT gate on `fs_cli -x "load mod_x"` into an already-running containerized
+FS. Measured during the v0.6.1 work: that path intermittently segfaults FS for
+ANY module — an unmodified baseline build died on manual load in 4 of 5 trials
+in `cb-fs-install-test`, while the same `.so` loaded fine every time on the
+autoload boot path (and under gdb's slowed startup). It is an in-container FS
+instability, not a module signal, and it produces convincing-looking false
+FAILs (and can mask real ones behind retries).
+
+For the gate, add the module to `autoload_configs/modules.conf.xml` in the
+container and assert `module_exists` after boot:
+
+```sh
+CONF=/usr/local/freeswitch/etc/freeswitch/autoload_configs/modules.conf.xml
+grep -q mod_audio_fork $CONF || \
+  sed -i 's|<load module="mod_aws_transcribe"/>|<load module="mod_aws_transcribe"/>\n    <load module="mod_audio_fork"/>|' $CONF
+# ...boot FS as above, then:
 [ "$(fs_cli -x 'module_exists mod_audio_fork'|tr -d '[:space:]')" = true ] && \
 [ "$(fs_cli -x 'show api'|grep -c '^uuid_audio_fork,')" -ge 1 ] && echo OK || { echo FAIL; exit 1; }
 ```
+
+If a manual `load` is unavoidable, wrap the WHOLE boot+load sequence in a
+retry loop (the mod_ttsd_transcribe `tests/loadtest` `bring_up()` pattern) and
+treat only repeated failures as a signal.
 
 Build is ~15–30 min at `JOBS=2`; the image is ~3.5 GB — delete it and the scratch
 context afterward. This catches real bugs: it caught a duplicate `m_gracefulShutdown`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -142,8 +142,12 @@ grep -oE 'switch_[a-z_]+' modules/<mod>/<file>.cpp | sort -u   # empty -> harnes
 ```
 
 The harness (`tests/soak/`) builds the **real** module source twice — once with
-`-fsanitize=address,undefined` and once with `-fsanitize=thread` — and drives,
-concurrently in a loop:
+`-fsanitize=address,undefined` and once with `-fsanitize=thread` — for BOTH
+lws AudioPipes (`mod_audio_fork` and, since v0.6.0, `mod_deepgram_transcribe`;
+deepgram dials TLS-only, so its soak covers the connect-fail/teardown/reaper
+surfaces plus a 200/200 reaper-completion gate, while its receive path is
+byte-identical to the mod_ttsd_transcribe AudioPipe soaked end-to-end in that
+repo) — and drives, concurrently in a loop:
 - the real lws service thread (started by `AudioPipe::initialize`),
 - a "media thread" that writes audio into the ring buffer exactly like the media-bug
   callback does,

--- a/modules/mod_audio_fork/README.md
+++ b/modules/mod_audio_fork/README.md
@@ -4,7 +4,7 @@ A Freeswitch module that attaches a bug to a media server endpoint and streams L
 
 #### Environment variables
 - MOD_AUDIO_FORK_SUBPROTOCOL_NAME - optional, name of the [websocket sub-protocol](https://tools.ietf.org/html/rfc6455#section-1.9) to advertise; defaults to "audio.drachtio.org"
-- MOD_AUDIO_FORK_SERVICE_THREADS - optional, number of libwebsocket service threads to create; these threads handling sending all messages for all sessions.  Defaults to 1, but can be set to as many as 5.
+- MOD_AUDIO_FORK_SERVICE_THREADS - optional, number of libwebsocket service threads to create; these threads handle sending all messages for all sessions. Defaults to 1. Since v0.6.1 values above 1 are capped to 1 (with an error log): multi-context connect adoption is not thread-safe (ThreadSanitizer-verified race in the shared pending-connect list; see CHANGELOG v0.6.0/v0.6.1).
 
 ## API
 

--- a/modules/mod_audio_fork/audio_pipe.cpp
+++ b/modules/mod_audio_fork/audio_pipe.cpp
@@ -104,6 +104,11 @@ int AudioPipe::lws_callback(struct lws *wsi,
           *ppAp = ap;
           ap->m_vhd = vhd;
           ap->m_state = LWS_CLIENT_CONNECTED;
+          // a close() issued while we were still CONNECTING recorded its intent
+          // in m_closePending; complete it now rather than leaking the pipe
+          if (ap->m_closePending) {
+            ap->close();
+          }
           ap->m_callback(ap->m_uuid.c_str(), ap->m_bugname.c_str(), AudioPipe::CONNECT_SUCCESS, NULL);
         }
         else {
@@ -503,6 +508,7 @@ AudioPipe::AudioPipe(const char* uuid, const char* host, unsigned int port, cons
   int sslFlags, size_t bufLen, size_t minFreespace, const char* username, const char* password, char* bugname, notifyHandler_t callback) :
   m_uuid(uuid), m_host(host), m_port(port), m_path(path), m_sslFlags(sslFlags),
   m_audio_buffer_min_freespace(minFreespace), m_audio_buffer_max_len(bufLen), m_gracefulShutdown(false),
+  m_closePending(false),
   m_audio_buffer_write_offset(LWS_PRE), m_recv_buf(nullptr), m_recv_buf_ptr(nullptr), m_bugname(bugname),
   m_state(LWS_CLIENT_IDLE), m_wsi(nullptr), m_vhd(nullptr), m_callback(callback),
   m_closeSignaled(false) {
@@ -567,7 +573,22 @@ void AudioPipe::unlockAudioBuffer() {
 }
 
 void AudioPipe::close() {
-  if (m_state != LWS_CLIENT_CONNECTED) return;
+  if (m_state != LWS_CLIENT_CONNECTED) {
+    // Not connected yet (still IDLE/CONNECTING): there is nothing to disconnect
+    // until the handshake completes. Remember the request so
+    // LWS_CALLBACK_CLIENT_ESTABLISHED can complete it once connected --
+    // previously this was silently dropped, and if the connect subsequently
+    // succeeded, nothing else ever called close() again for this pipe: the
+    // reaper's detached thread blocked forever in waitForClose() and the
+    // connection leaked for the rest of the process's life.
+    m_closePending = true;
+    // the connect may have completed concurrently between the state check
+    // above and setting the flag; re-check rather than depending solely on
+    // ESTABLISHED's own read of m_closePending, which could already have run
+    // (and seen it as still false) in that window
+    // cppcheck-suppress identicalInnerCondition
+    if (m_state != LWS_CLIENT_CONNECTED) return;
+  }
   addPendingDisconnect(this);
 }
 

--- a/modules/mod_audio_fork/audio_pipe.cpp
+++ b/modules/mod_audio_fork/audio_pipe.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <iostream>
+#include <vector>
 
 /* discard incoming text messages over the socket that are longer than this */
 #define MAX_RECV_BUF_SIZE (65 * 1024 * 10)
@@ -64,7 +65,10 @@ int AudioPipe::lws_callback(struct lws *wsi,
 
           ap->getBasicAuth(username, password);
           lwsl_notice("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_APPEND_HANDSHAKE_HEADER username: %s, password: xxxxxx\n", username.c_str());
-          if (dch_lws_http_basic_auth_gen(username.c_str(), password.c_str(), b, sizeof(b))) break;
+          if (dch_lws_http_basic_auth_gen(username.c_str(), password.c_str(), b, sizeof(b))) {
+            lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_APPEND_HANDSHAKE_HEADER failed generating basic auth header; failing handshake to avoid sending an unauthenticated request\n");
+            return -1;
+          }
           if (lws_add_http_header_by_token(wsi, WSI_TOKEN_HTTP_AUTHORIZATION, (unsigned char *)b, strlen(b), p, end)) return -1;
         }
       }
@@ -100,7 +104,7 @@ int AudioPipe::lws_callback(struct lws *wsi,
           ap->m_callback(ap->m_uuid.c_str(), ap->m_bugname.c_str(), AudioPipe::CONNECT_SUCCESS, NULL);
         }
         else {
-          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_ESTABLISHED %s unable to find wsi %p..\n", ap->m_uuid.c_str(), wsi); 
+          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_ESTABLISHED unable to find wsi %p..\n", wsi);
         }
       }      
       break;
@@ -108,7 +112,7 @@ int AudioPipe::lws_callback(struct lws *wsi,
       {
         AudioPipe* ap = *ppAp;
         if (!ap) {
-          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_CLOSED %s unable to find wsi %p..\n", ap->m_uuid.c_str(), wsi); 
+          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_CLOSED unable to find wsi %p..\n", wsi);
           return 0;
         }
         if (ap->m_state == LWS_CLIENT_DISCONNECTING) {
@@ -134,7 +138,7 @@ int AudioPipe::lws_callback(struct lws *wsi,
       {
         AudioPipe* ap = *ppAp;
         if (!ap) {
-          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_RECEIVE %s unable to find wsi %p..\n", ap->m_uuid.c_str(), wsi); 
+          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_RECEIVE unable to find wsi %p..\n", wsi);
           return 0;
         }
 
@@ -193,7 +197,7 @@ int AudioPipe::lws_callback(struct lws *wsi,
       {
         AudioPipe* ap = *ppAp;
         if (!ap) {
-          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_WRITEABLE %s unable to find wsi %p..\n", ap->m_uuid.c_str(), wsi); 
+          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_WRITEABLE unable to find wsi %p..\n", wsi);
           return 0;
         }
 
@@ -209,10 +213,10 @@ int AudioPipe::lws_callback(struct lws *wsi,
         {
           std::lock_guard<std::mutex> lk(ap->m_text_mutex);
           if (ap->m_metadata.length() > 0) {
-            uint8_t buf[ap->m_metadata.length() + LWS_PRE];
-            memcpy(buf + LWS_PRE, ap->m_metadata.c_str(), ap->m_metadata.length());
+            std::vector<uint8_t> buf(ap->m_metadata.length() + LWS_PRE);
+            memcpy(buf.data() + LWS_PRE, ap->m_metadata.c_str(), ap->m_metadata.length());
             int n = ap->m_metadata.length();
-            int m = lws_write(wsi, buf + LWS_PRE, n, LWS_WRITE_TEXT);
+            int m = lws_write(wsi, buf.data() + LWS_PRE, n, LWS_WRITE_TEXT);
             ap->m_metadata.clear();
             if (m < n) {
               return -1;
@@ -279,7 +283,6 @@ std::mutex AudioPipe::mutex_writes;
 std::list<AudioPipe*> AudioPipe::pendingConnects;
 std::list<AudioPipe*> AudioPipe::pendingDisconnects;
 std::list<AudioPipe*> AudioPipe::pendingWrites;
-AudioPipe::log_emit_function AudioPipe::logger;
 std::mutex AudioPipe::mapMutex;
 std::unordered_map<std::thread::id, bool> AudioPipe::stopFlags;
 std::queue<std::thread::id> AudioPipe::threadIds;

--- a/modules/mod_audio_fork/audio_pipe.cpp
+++ b/modules/mod_audio_fork/audio_pipe.cpp
@@ -409,6 +409,17 @@ void AudioPipe::addPendingWrite(AudioPipe* ap) {
   lws_cancel_service(ap->m_vhd->context);
 }
 
+void AudioPipe::removeFromPending(AudioPipe* ap) {
+  // Each list is processed by the lws service thread under its own mutex
+  // (processPendingConnects/Disconnects/Writes read (*it)->m_state there), so
+  // taking the same mutex here serializes removal with those reads: the pipe is
+  // either still present and read while alive, or already gone — never read after
+  // free. Locks are taken one at a time (never nested), so no lock-order deadlock.
+  { std::lock_guard<std::mutex> guard(mutex_connects);    pendingConnects.remove(ap); }
+  { std::lock_guard<std::mutex> guard(mutex_disconnects); pendingDisconnects.remove(ap); }
+  { std::lock_guard<std::mutex> guard(mutex_writes);      pendingWrites.remove(ap); }
+}
+
 bool AudioPipe::lws_service_thread(unsigned int nServiceThread) {
   struct lws_context_creation_info info;
 
@@ -504,6 +515,9 @@ AudioPipe::AudioPipe(const char* uuid, const char* host, unsigned int port, cons
   m_audio_buffer = new uint8_t[m_audio_buffer_max_len];
 }
 AudioPipe::~AudioPipe() {
+  // Drop any lingering references before freeing so the lws service thread cannot
+  // dereference this pipe after it is gone (see removeFromPending).
+  removeFromPending(this);
   if (m_audio_buffer) delete [] m_audio_buffer;
   if (m_recv_buf) delete [] m_recv_buf;
 }

--- a/modules/mod_audio_fork/audio_pipe.cpp
+++ b/modules/mod_audio_fork/audio_pipe.cpp
@@ -159,9 +159,31 @@ int AudioPipe::lws_callback(struct lws *wsi,
         if (lws_is_first_fragment(wsi)) {
           // allocate a buffer for the entire chunk of memory needed
           assert(nullptr == ap->m_recv_buf);
+          ap->m_recv_buf_discarding = false;
           ap->m_recv_buf_len = len + lws_remaining_packet_payload(wsi);
           ap->m_recv_buf = (uint8_t*) malloc(ap->m_recv_buf_len);
+          if (nullptr == ap->m_recv_buf) {
+            lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_RECEIVE recv buffer alloc failed, dropping message.\n");
+            ap->m_recv_buf_len = 0;
+            ap->m_recv_buf_discarding = !lws_is_final_fragment(wsi);
+            return 0;
+          }
           ap->m_recv_buf_ptr = ap->m_recv_buf;
+        }
+
+        if (ap->m_recv_buf_discarding) {
+          // Already abandoned this message (oversized, or its buffer alloc
+          // failed) on an earlier fragment. lws's first/final-fragment tracking
+          // is per-message, not aware of that abandonment, so without this
+          // check the code below would treat this continuation fragment as the
+          // start of a brand-new message -- and if it happens to be the
+          // message's final fragment, would deliver a truncated/garbled tail as
+          // a "complete" message instead of dropping it. Keep dropping
+          // fragments until the (abandoned) message actually ends.
+          if (lws_is_final_fragment(wsi)) {
+            ap->m_recv_buf_discarding = false;
+          }
+          return 0;
         }
 
         size_t write_offset = ap->m_recv_buf_ptr - ap->m_recv_buf;
@@ -173,13 +195,27 @@ int AudioPipe::lws_callback(struct lws *wsi,
             free(ap->m_recv_buf);
             ap->m_recv_buf = ap->m_recv_buf_ptr = nullptr;
             ap->m_recv_buf_len = 0;
+            ap->m_recv_buf_discarding = !lws_is_final_fragment(wsi);
             lwsl_notice("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_RECEIVE max buffer exceeded, truncating message.\n");
           }
           else {
-            ap->m_recv_buf = (uint8_t*) realloc(ap->m_recv_buf, newlen);
-            if (nullptr != ap->m_recv_buf) {
+            uint8_t* grown = (uint8_t*) realloc(ap->m_recv_buf, newlen);
+            if (nullptr != grown) {
+              ap->m_recv_buf = grown;
               ap->m_recv_buf_len = newlen;
               ap->m_recv_buf_ptr = ap->m_recv_buf + write_offset;
+            }
+            else {
+              // realloc failure leaves the original block valid: assigning the
+              // nullptr over m_recv_buf directly would leak it and leave
+              // m_recv_buf_ptr/m_recv_buf_len stale (poisoning the offset math
+              // of every later fragment). Drop the message and free the old
+              // buffer instead, then swallow fragments until it ends.
+              lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_RECEIVE recv buffer realloc failed, dropping message.\n");
+              free(ap->m_recv_buf);
+              ap->m_recv_buf = ap->m_recv_buf_ptr = nullptr;
+              ap->m_recv_buf_len = 0;
+              ap->m_recv_buf_discarding = !lws_is_final_fragment(wsi);
             }
           }
         }
@@ -509,7 +545,8 @@ AudioPipe::AudioPipe(const char* uuid, const char* host, unsigned int port, cons
   m_uuid(uuid), m_host(host), m_port(port), m_path(path), m_sslFlags(sslFlags),
   m_audio_buffer_min_freespace(minFreespace), m_audio_buffer_max_len(bufLen), m_gracefulShutdown(false),
   m_closePending(false),
-  m_audio_buffer_write_offset(LWS_PRE), m_recv_buf(nullptr), m_recv_buf_ptr(nullptr), m_bugname(bugname),
+  m_audio_buffer_write_offset(LWS_PRE), m_recv_buf(nullptr), m_recv_buf_ptr(nullptr),
+  m_recv_buf_discarding(false), m_bugname(bugname),
   m_state(LWS_CLIENT_IDLE), m_wsi(nullptr), m_vhd(nullptr), m_callback(callback),
   m_closeSignaled(false) {
 

--- a/modules/mod_audio_fork/audio_pipe.cpp
+++ b/modules/mod_audio_fork/audio_pipe.cpp
@@ -87,9 +87,12 @@ int AudioPipe::lws_callback(struct lws *wsi,
         if (ap) {
           ap->m_state = LWS_CLIENT_FAILED;
           ap->m_callback(ap->m_uuid.c_str(), ap->m_bugname.c_str(), AudioPipe::CONNECT_FAIL, (char *) in);
+          // terminal: no LWS_CALLBACK_CLIENT_CLOSED follows a failed connect, so
+          // fulfill the close promise here or the reaper would block forever.
+          ap->setClosed();
         }
         else {
-          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_CONNECTION_ERROR unable to find wsi %p..\n", wsi); 
+          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_CONNECTION_ERROR unable to find wsi %p..\n", wsi);
         }
       }      
       break;
@@ -126,11 +129,12 @@ int AudioPipe::lws_callback(struct lws *wsi,
         }
         ap->m_state = LWS_CLIENT_DISCONNECTED;
 
-        //NB: after receiving any of the events above, any holder of a 
-        //pointer or reference to this object must treat is as no longer valid
-
+        //NB: the AudioPipe is NOT deleted here. The lws service thread may not be
+        //the last user of it (a media-bug thread could still hold it), so deletion
+        //is deferred to the reaper, which deletes only after the media bug has been
+        //removed AND this close has been signalled. We just fulfill the promise.
+        ap->setClosed();
         *ppAp = NULL;
-        delete ap;
       }
       break;
 
@@ -300,7 +304,15 @@ void AudioPipe::processPendingConnects(lws_per_vhost_data *vhd) {
   }
   for (auto it = connects.begin(); it != connects.end(); ++it) {
     AudioPipe* ap = *it;
-    ap->connect_client(vhd);   
+    if (!ap->connect_client(vhd)) {
+      // synchronous connect failure: no wsi was created, so no CONNECTION_ERROR /
+      // CLOSED callback will follow. Notify and fulfill the close promise so the
+      // reaper can delete the pipe instead of blocking forever.
+      lwsl_err("%s connect_client failed synchronously\n", ap->m_uuid.c_str());
+      ap->m_state = LWS_CLIENT_FAILED;
+      ap->m_callback(ap->m_uuid.c_str(), ap->m_bugname.c_str(), AudioPipe::CONNECT_FAIL, (char *) "connect_client failed");
+      ap->setClosed();
+    }
   }
 }
 
@@ -498,7 +510,8 @@ AudioPipe::AudioPipe(const char* uuid, const char* host, unsigned int port, cons
   m_uuid(uuid), m_host(host), m_port(port), m_path(path), m_sslFlags(sslFlags),
   m_audio_buffer_min_freespace(minFreespace), m_audio_buffer_max_len(bufLen), m_gracefulShutdown(false),
   m_audio_buffer_write_offset(LWS_PRE), m_recv_buf(nullptr), m_recv_buf_ptr(nullptr), m_bugname(bugname),
-  m_state(LWS_CLIENT_IDLE), m_wsi(nullptr), m_vhd(nullptr), m_callback(callback) {
+  m_state(LWS_CLIENT_IDLE), m_wsi(nullptr), m_vhd(nullptr), m_callback(callback),
+  m_closeSignaled(false) {
 
   if (username && password) {
     m_username.assign(username);
@@ -564,4 +577,20 @@ void AudioPipe::close() {
 void AudioPipe::do_graceful_shutdown() {
   m_gracefulShutdown = true;
   addPendingWrite(this);
+}
+
+void AudioPipe::setClosed() {
+  // set-once: fulfill the promise exactly once no matter which terminal path runs
+  bool expected = false;
+  if (m_closeSignaled.compare_exchange_strong(expected, true)) {
+    m_promise.set_value();
+  }
+}
+
+void AudioPipe::waitForClose() {
+  // blocks until the connection is terminally closed (CLOSED / CONNECT_FAIL).
+  // Unbounded by design: deleting before the lws thread is done with this object
+  // would be a use-after-free, so we never time out and delete early.
+  std::future<void> f = m_promise.get_future();
+  f.wait();
 }

--- a/modules/mod_audio_fork/audio_pipe.cpp
+++ b/modules/mod_audio_fork/audio_pipe.cpp
@@ -287,9 +287,8 @@ std::mutex AudioPipe::mutex_writes;
 std::list<AudioPipe*> AudioPipe::pendingConnects;
 std::list<AudioPipe*> AudioPipe::pendingDisconnects;
 std::list<AudioPipe*> AudioPipe::pendingWrites;
-std::mutex AudioPipe::mapMutex;
-std::unordered_map<std::thread::id, bool> AudioPipe::stopFlags;
-std::queue<std::thread::id> AudioPipe::threadIds;
+std::atomic<bool> AudioPipe::stopRequested{false};
+std::vector<std::thread> AudioPipe::serviceThreads;
 
 void AudioPipe::processPendingConnects(lws_per_vhost_data *vhd) {
   std::list<AudioPipe*> connects;
@@ -411,7 +410,6 @@ void AudioPipe::addPendingWrite(AudioPipe* ap) {
 }
 
 bool AudioPipe::lws_service_thread(unsigned int nServiceThread) {
-  std::thread::id this_id = std::this_thread::get_id();
   struct lws_context_creation_info info;
 
   const struct lws_protocols protocols[] = {
@@ -448,14 +446,9 @@ bool AudioPipe::lws_service_thread(unsigned int nServiceThread) {
   int n;
   do {
     n = lws_service(contexts[nServiceThread], 0);
-  } while (n >= 0 && !stopFlags[this_id]);
+  } while (n >= 0 && !stopRequested.load());
 
-  // Cleanup once work is done or stopped
-  {
-      std::lock_guard<std::mutex> lock(mapMutex);
-      stopFlags.erase(this_id);
-  }
-  lwsl_notice("AudioPipe::lws_service_thread ending in service thread %d\n", nServiceThread); 
+  lwsl_notice("AudioPipe::lws_service_thread ending in service thread %d\n", nServiceThread);
   return true;
 }
 
@@ -467,40 +460,30 @@ void AudioPipe::initialize(const char* protocol, unsigned int nThreads, int logl
   lws_set_log_level(loglevel, logger);
 
   lwsl_notice("AudioPipe::initialize starting %d threads with subprotocol %s\n", nThreads, protocol); 
+  stopRequested.store(false);
   for (unsigned int i = 0; i < numContexts; i++) {
-    std::lock_guard<std::mutex> lock(mapMutex);
-    std::thread t(&AudioPipe::lws_service_thread, i);
-    stopFlags[t.get_id()] = false;
-    threadIds.push(t.get_id());
-    t.detach();
+    serviceThreads.emplace_back(&AudioPipe::lws_service_thread, i);
   }
 }
 
 bool AudioPipe::deinitialize() {
-  lwsl_notice("AudioPipe::deinitialize\n"); 
-  std::lock_guard<std::mutex> lock(mapMutex);
-  if (!threadIds.empty()) {
-      std::thread::id id = threadIds.front();
-      threadIds.pop();
-      stopFlags[id] = true;
+  lwsl_notice("AudioPipe::deinitialize\n");
+  // Signal every service thread to stop, wake each lws context out of
+  // lws_service(), and JOIN the threads before destroying their contexts. This
+  // replaces the old detached-thread + per-iteration map-read shutdown, which
+  // raced the service thread against teardown (and only stopped one of N threads).
+  stopRequested.store(true);
+  for (unsigned int i = 0; i < numContexts; i++) {
+    if (contexts[i]) lws_cancel_service(contexts[i]);
   }
-/*
-  do
-  {
-    lwsl_notice("waiting for pending connects to complete\n");
-  } while (pendingConnects.size() > 0);
-  do
-  {
-    lwsl_notice("waiting for disconnects to complete\n");
-  } while (pendingDisconnects.size() > 0);
-*/
-
-  for (unsigned int i = 0; i < numContexts; i++)
-  {
+  for (auto& t : serviceThreads) {
+    if (t.joinable()) t.join();
+  }
+  serviceThreads.clear();
+  for (unsigned int i = 0; i < numContexts; i++) {
     lwsl_notice("AudioPipe::deinitialize destroying context %d of %d\n", i + 1, numContexts);
-    lws_context_destroy(contexts[i]);
+    if (contexts[i]) { lws_context_destroy(contexts[i]); contexts[i] = nullptr; }
   }
-  std::this_thread::sleep_for(std::chrono::seconds(2));
   return true;
 }
 

--- a/modules/mod_audio_fork/audio_pipe.cpp
+++ b/modules/mod_audio_fork/audio_pipe.cpp
@@ -286,7 +286,10 @@ int AudioPipe::lws_callback(struct lws *wsi,
           if (ap->m_audio_buffer_write_offset > LWS_PRE) {
             size_t datalen = ap->m_audio_buffer_write_offset - LWS_PRE;
             int sent = lws_write(wsi, (unsigned char *) ap->m_audio_buffer + LWS_PRE, datalen, LWS_WRITE_BINARY);
-            if (sent < datalen) {
+            /* lws_write returns int (-1 on fatal error); comparing it against
+               the size_t datalen promoted -1 to SIZE_MAX and skipped the error
+               branch entirely, so write failures were silently discarded */
+            if (sent < (int) datalen) {
               lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_WRITEABLE %s attemped to send %lu only sent %d wsi %p..\n", 
                 ap->m_uuid.c_str(), datalen, sent, wsi); 
             }
@@ -562,7 +565,10 @@ AudioPipe::~AudioPipe() {
   // dereference this pipe after it is gone (see removeFromPending).
   removeFromPending(this);
   if (m_audio_buffer) delete [] m_audio_buffer;
-  if (m_recv_buf) delete [] m_recv_buf;
+  /* m_recv_buf is malloc/realloc'd by the receive path -- it must be free()d,
+     not delete[]d (mismatched allocator is UB and ASan-fatal). Non-null here
+     whenever the pipe dies with a fragmented message still in flight. */
+  if (m_recv_buf) free(m_recv_buf);
 }
 
 void AudioPipe::connect(void) {

--- a/modules/mod_audio_fork/audio_pipe.cpp
+++ b/modules/mod_audio_fork/audio_pipe.cpp
@@ -279,7 +279,7 @@ struct lws_context *AudioPipe::contexts[] = {
   nullptr, nullptr, nullptr, nullptr, nullptr
 };
 unsigned int AudioPipe::numContexts = 0;
-unsigned int AudioPipe::nchild = 0;
+std::atomic<unsigned int> AudioPipe::nchild{0};
 std::string AudioPipe::protocolName;
 std::mutex AudioPipe::mutex_connects;
 std::mutex AudioPipe::mutex_disconnects;

--- a/modules/mod_audio_fork/audio_pipe.cpp
+++ b/modules/mod_audio_fork/audio_pipe.cpp
@@ -77,7 +77,7 @@ int AudioPipe::lws_callback(struct lws *wsi,
     case LWS_CALLBACK_EVENT_WAIT_CANCELLED:
       processPendingConnects(vhd);
       processPendingDisconnects(vhd);
-      processPendingWrites();
+      processPendingWrites(vhd);
       break;
     case LWS_CALLBACK_CLIENT_CONNECTION_ERROR:
       {
@@ -318,9 +318,9 @@ static const lws_retry_bo_t retry = {
     0          // jitter_percent
 };
 
-struct lws_context *AudioPipe::contexts[] = {
-  nullptr, nullptr, nullptr, nullptr, nullptr,
-  nullptr, nullptr, nullptr, nullptr, nullptr
+std::atomic<struct lws_context*> AudioPipe::contexts[] = {
+  {nullptr}, {nullptr}, {nullptr}, {nullptr}, {nullptr},
+  {nullptr}, {nullptr}, {nullptr}, {nullptr}, {nullptr}
 };
 unsigned int AudioPipe::numContexts = 0;
 std::atomic<unsigned int> AudioPipe::nchild{0};
@@ -360,28 +360,45 @@ void AudioPipe::processPendingConnects(lws_per_vhost_data *vhd) {
 }
 
 void AudioPipe::processPendingDisconnects(lws_per_vhost_data *vhd) {
+  /* Only service pipes owned by THIS thread's context. lws wsi objects are not
+     thread-safe: with MOD_AUDIO_FORK_SERVICE_THREADS > 1 every context has its
+     own service thread, and the only lws call that may cross threads is
+     lws_cancel_service (which is how these lists get drained -- each add wakes
+     the owning pipe's context). Draining another context's entries here would
+     invoke lws_callback_on_writable on a wsi its own thread may be servicing
+     concurrently. Entries for other contexts are left in place for their own
+     thread's wakeup to process. */
   std::list<AudioPipe*> disconnects;
   {
     std::lock_guard<std::mutex> guard(mutex_disconnects);
-    for (auto it = pendingDisconnects.begin(); it != pendingDisconnects.end(); ++it) {
-      if ((*it)->m_state == LWS_CLIENT_DISCONNECTING) disconnects.push_back(*it);
+    for (auto it = pendingDisconnects.begin(); it != pendingDisconnects.end(); ) {
+      AudioPipe* ap = *it;
+      if (ap->m_vhd && ap->m_vhd->context == vhd->context) {
+        if (ap->m_state == LWS_CLIENT_DISCONNECTING) disconnects.push_back(ap);
+        it = pendingDisconnects.erase(it);
+      }
+      else ++it;
     }
-    pendingDisconnects.clear();
   }
   for (auto it = disconnects.begin(); it != disconnects.end(); ++it) {
     AudioPipe* ap = *it;
-    lws_callback_on_writable(ap->m_wsi); 
+    lws_callback_on_writable(ap->m_wsi);
   }
 }
 
-void AudioPipe::processPendingWrites() {
+void AudioPipe::processPendingWrites(lws_per_vhost_data *vhd) {
+  /* per-context filtering: see processPendingDisconnects */
   std::list<AudioPipe*> writes;
   {
     std::lock_guard<std::mutex> guard(mutex_writes);
-    for (auto it = pendingWrites.begin(); it != pendingWrites.end(); ++it) {
-       if ((*it)->m_state == LWS_CLIENT_CONNECTED) writes.push_back(*it);
-    }  
-    pendingWrites.clear();
+    for (auto it = pendingWrites.begin(); it != pendingWrites.end(); ) {
+      AudioPipe* ap = *it;
+      if (ap->m_vhd && ap->m_vhd->context == vhd->context) {
+        if (ap->m_state == LWS_CLIENT_CONNECTED) writes.push_back(ap);
+        it = pendingWrites.erase(it);
+      }
+      else ++it;
+    }
   }
   for (auto it = writes.begin(); it != writes.end(); ++it) {
     AudioPipe* ap = *it;
@@ -427,13 +444,26 @@ AudioPipe* AudioPipe::findPendingConnect(struct lws *wsi) {
 }
 
 void AudioPipe::addPendingConnect(AudioPipe* ap) {
+  /* a service thread whose lws_create_context failed leaves its slot NULL;
+     round-robin over the live ones instead of dereferencing a dead slot */
+  struct lws_context* ctx = nullptr;
+  for (unsigned int i = 0; i < numContexts && !ctx; i++) {
+    ctx = contexts[nchild++ % numContexts];
+  }
+  if (!ctx) {
+    lwsl_err("%s AudioPipe::addPendingConnect no live lws context, failing connect\n", ap->m_uuid.c_str());
+    ap->m_state = LWS_CLIENT_FAILED;
+    ap->m_callback(ap->m_uuid.c_str(), ap->m_bugname.c_str(), AudioPipe::CONNECT_FAIL, "no lws context available");
+    ap->setClosed();  // keep the reaper's waitForClose() from blocking forever
+    return;
+  }
   {
     std::lock_guard<std::mutex> guard(mutex_connects);
     pendingConnects.push_back(ap);
-    lwsl_notice("%s after adding connect there are %lu pending connects\n", 
+    lwsl_notice("%s after adding connect there are %lu pending connects\n",
       ap->m_uuid.c_str(), pendingConnects.size());
   }
-  lws_cancel_service(contexts[nchild++ % numContexts]);
+  lws_cancel_service(ctx);
 }
 void AudioPipe::addPendingDisconnect(AudioPipe* ap) {
   ap->m_state = LWS_CLIENT_DISCONNECTING;
@@ -492,15 +522,16 @@ bool AudioPipe::lws_service_thread(unsigned int nServiceThread) {
 
   lwsl_notice("AudioPipe::lws_service_thread creating context in service thread %d.\n", nServiceThread);
 
-  contexts[nServiceThread] = lws_create_context(&info);
-  if (!contexts[nServiceThread]) {
-    lwsl_err("AudioPipe::lws_service_thread failed creating context in service thread %d..\n", nServiceThread); 
+  struct lws_context* myContext = lws_create_context(&info);
+  contexts[nServiceThread].store(myContext);
+  if (!myContext) {
+    lwsl_err("AudioPipe::lws_service_thread failed creating context in service thread %d..\n", nServiceThread);
     return false;
   }
 
   int n;
   do {
-    n = lws_service(contexts[nServiceThread], 0);
+    n = lws_service(myContext, 0);
   } while (n >= 0 && !stopRequested.load());
 
   lwsl_notice("AudioPipe::lws_service_thread ending in service thread %d\n", nServiceThread);
@@ -509,12 +540,25 @@ bool AudioPipe::lws_service_thread(unsigned int nServiceThread) {
 
 void AudioPipe::initialize(const char* protocol, unsigned int nThreads, int loglevel, log_emit_function logger) {
   assert(nThreads > 0 && nThreads <= 10);
+  lws_set_log_level(loglevel, logger);
+
+  if (nThreads > 1) {
+    /* Multi-context mode is capped to one service thread: the pending-CONNECT
+       list is shared across contexts, and the adopting service thread writes
+       ap->m_wsi / ap->m_vhd in connect_client() while another context's
+       ESTABLISHED/ERROR callback scans exactly those fields under
+       mutex_connects -- a ThreadSanitizer-verified data race in the identical
+       deepgram AudioPipe (and libwebsockets' own logging path also races
+       across service threads). Re-enable only after connect adoption is made
+       per-context. */
+    lwsl_err("AudioPipe::initialize %d service threads requested; capped to 1 (multi-context connect adoption is not thread-safe)\n", nThreads);
+    nThreads = 1;
+  }
 
   numContexts = nThreads;
   protocolName = protocol;
-  lws_set_log_level(loglevel, logger);
 
-  lwsl_notice("AudioPipe::initialize starting %d threads with subprotocol %s\n", nThreads, protocol); 
+  lwsl_notice("AudioPipe::initialize starting %d threads with subprotocol %s\n", nThreads, protocol);
   stopRequested.store(false);
   for (unsigned int i = 0; i < numContexts; i++) {
     serviceThreads.emplace_back(&AudioPipe::lws_service_thread, i);

--- a/modules/mod_audio_fork/audio_pipe.hpp
+++ b/modules/mod_audio_fork/audio_pipe.hpp
@@ -100,7 +100,7 @@ public:
 private:
 
   static int lws_callback(struct lws *wsi, enum lws_callback_reasons reason, void *user, void *in, size_t len); 
-  static unsigned int nchild;
+  static std::atomic<unsigned int> nchild;
   static struct lws_context *contexts[];
   static unsigned int numContexts;
   static std::string protocolName;

--- a/modules/mod_audio_fork/audio_pipe.hpp
+++ b/modules/mod_audio_fork/audio_pipe.hpp
@@ -123,6 +123,10 @@ private:
   static void addPendingConnect(AudioPipe* ap);
   static void addPendingDisconnect(AudioPipe* ap);
   static void addPendingWrite(AudioPipe* ap);
+  /* Remove ap from every pending list under the list mutexes. Called from the
+     destructor so a reaped pipe cannot be dereferenced by the lws service thread
+     (which reads (*it)->m_state under those same mutexes) after it is freed. */
+  static void removeFromPending(AudioPipe* ap);
   static void processPendingConnects(lws_per_vhost_data *vhd);
   static void processPendingDisconnects(lws_per_vhost_data *vhd);
   static void processPendingWrites(void);

--- a/modules/mod_audio_fork/audio_pipe.hpp
+++ b/modules/mod_audio_fork/audio_pipe.hpp
@@ -159,6 +159,10 @@ private:
   std::string m_password;
   /* cross-thread flag (written by graceful-shutdown path, read by lws callback) */
   std::atomic<bool> m_gracefulShutdown;
+  /* a close() that arrived while the WS handshake was still in flight; completed
+     by LWS_CALLBACK_CLIENT_ESTABLISHED so the reaper's waitForClose() cannot
+     block forever on a connection nothing will ever close */
+  std::atomic<bool> m_closePending;
   /* set-once guard so the close promise is fulfilled exactly once regardless of
      which terminal path (graceful close, far-end drop, or connect failure) runs */
   std::atomic<bool> m_closeSignaled;

--- a/modules/mod_audio_fork/audio_pipe.hpp
+++ b/modules/mod_audio_fork/audio_pipe.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <list>
+#include <atomic>
 #include <mutex>
 #include <queue>
 #include <unordered_map>
@@ -61,7 +62,7 @@ public:
     m_audio_buffer_write_offset += len;
   }
   void binaryWritePtrResetToZero(void) {
-    m_audio_buffer_write_offset = 0;
+    m_audio_buffer_write_offset = LWS_PRE;
   }
   void lockAudioBuffer(void) {
     m_audio_mutex.lock();
@@ -101,7 +102,6 @@ private:
   static std::list<AudioPipe*> pendingConnects;
   static std::list<AudioPipe*> pendingDisconnects;
   static std::list<AudioPipe*> pendingWrites;
-  static log_emit_function logger;
 
   static std::mutex mapMutex;
   static std::unordered_map<std::thread::id, bool> stopFlags;
@@ -118,7 +118,9 @@ private:
   
   bool connect_client(struct lws_per_vhost_data *vhd);
 
-  LwsState_t m_state;
+  /* connection-state flag shared between the lws service thread and the
+     media-bug threads; atomic so reads/writes don't race (seq_cst) */
+  std::atomic<LwsState_t> m_state;
   std::string m_uuid;
   std::string m_host;
   std::string m_bugname;
@@ -138,10 +140,10 @@ private:
   size_t m_recv_buf_len;
   struct lws_per_vhost_data* m_vhd;
   notifyHandler_t m_callback;
-  log_emit_function m_logger;
   std::string m_username;
   std::string m_password;
-  bool m_gracefulShutdown;
+  /* cross-thread flag (written by graceful-shutdown path, read by lws callback) */
+  std::atomic<bool> m_gracefulShutdown;
 };
 
 #endif

--- a/modules/mod_audio_fork/audio_pipe.hpp
+++ b/modules/mod_audio_fork/audio_pipe.hpp
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <thread>
 #include <future>
+#include <vector>
 
 #include <libwebsockets.h>
 
@@ -111,9 +112,11 @@ private:
   static std::list<AudioPipe*> pendingDisconnects;
   static std::list<AudioPipe*> pendingWrites;
 
-  static std::mutex mapMutex;
-  static std::unordered_map<std::thread::id, bool> stopFlags;
-  static std::queue<std::thread::id> threadIds;
+  /* shutdown coordination: deinitialize() sets stopRequested, wakes each lws
+     context, and JOINs the (non-detached) service threads before destroying the
+     contexts, so no service thread races teardown. */
+  static std::atomic<bool> stopRequested;
+  static std::vector<std::thread> serviceThreads;
 
   static AudioPipe* findAndRemovePendingConnect(struct lws *wsi);
   static AudioPipe* findPendingConnect(struct lws *wsi);

--- a/modules/mod_audio_fork/audio_pipe.hpp
+++ b/modules/mod_audio_fork/audio_pipe.hpp
@@ -102,7 +102,10 @@ private:
 
   static int lws_callback(struct lws *wsi, enum lws_callback_reasons reason, void *user, void *in, size_t len); 
   static std::atomic<unsigned int> nchild;
-  static struct lws_context *contexts[];
+  /* written by each service thread at startup (lws_create_context) and read
+     by connecting threads (addPendingConnect/addPendingWrite wake targets);
+     atomic slots give those cross-thread accesses a happens-before edge */
+  static std::atomic<struct lws_context*> contexts[];
   static unsigned int numContexts;
   static std::string protocolName;
   static std::mutex mutex_connects;
@@ -129,7 +132,7 @@ private:
   static void removeFromPending(AudioPipe* ap);
   static void processPendingConnects(lws_per_vhost_data *vhd);
   static void processPendingDisconnects(lws_per_vhost_data *vhd);
-  static void processPendingWrites(void);
+  static void processPendingWrites(lws_per_vhost_data *vhd);
   
   bool connect_client(struct lws_per_vhost_data *vhd);
 

--- a/modules/mod_audio_fork/audio_pipe.hpp
+++ b/modules/mod_audio_fork/audio_pipe.hpp
@@ -153,6 +153,10 @@ private:
   uint8_t* m_recv_buf;
   uint8_t* m_recv_buf_ptr;
   size_t m_recv_buf_len;
+  /* true while dropping the remaining fragments of an inbound message that was
+     abandoned mid-delivery (oversized, or its buffer allocation failed); only
+     ever touched on the lws service thread */
+  bool m_recv_buf_discarding;
   struct lws_per_vhost_data* m_vhd;
   notifyHandler_t m_callback;
   std::string m_username;

--- a/modules/mod_audio_fork/audio_pipe.hpp
+++ b/modules/mod_audio_fork/audio_pipe.hpp
@@ -8,6 +8,7 @@
 #include <queue>
 #include <unordered_map>
 #include <thread>
+#include <future>
 
 #include <libwebsockets.h>
 
@@ -84,6 +85,13 @@ public:
 
   void close() ;
 
+  // Promise-based close signalling. The lws CLOSED / CONNECT_FAIL paths call
+  // setClosed() (set-once); the reaper blocks in waitForClose() before deleting
+  // the AudioPipe, so the object always outlives any lws-thread use of it.
+  // This replaces the previous (racy) delete-inside-the-lws-callback model.
+  void setClosed();
+  void waitForClose();
+
   // no default constructor or copying
   AudioPipe() = delete;
   AudioPipe(const AudioPipe&) = delete;
@@ -144,6 +152,10 @@ private:
   std::string m_password;
   /* cross-thread flag (written by graceful-shutdown path, read by lws callback) */
   std::atomic<bool> m_gracefulShutdown;
+  /* set-once guard so the close promise is fulfilled exactly once regardless of
+     which terminal path (graceful close, far-end drop, or connect failure) runs */
+  std::atomic<bool> m_closeSignaled;
+  std::promise<void> m_promise;
 };
 
 #endif

--- a/modules/mod_audio_fork/lws_glue.cpp
+++ b/modules/mod_audio_fork/lws_glue.cpp
@@ -36,7 +36,7 @@ namespace {
     std::string type;
     cJSON* json = parse_json(session, msg, type) ;
     if (json) {
-      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "(%u) processIncomingMessage - received %s message\n", tech_pvt->id, type.c_str());
+      switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "(%u) processIncomingMessage - received %s message\n", tech_pvt->id, type.c_str());
       cJSON* jsonData = cJSON_GetObjectItem(json, "data");
       if (0 == type.compare("playAudio")) {
         if (jsonData) {
@@ -81,7 +81,7 @@ namespace {
           }
           else {
             validAudio = 0;
-            switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "(%u) processIncomingMessage - unsupported audioContentType: %s\n", tech_pvt->id, szAudioContentType);
+            switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "(%u) processIncomingMessage - unsupported audioContentType: %s\n", tech_pvt->id, szAudioContentType);
           }
 
           if (validAudio) {
@@ -111,7 +111,7 @@ namespace {
           if (jsonAudio) cJSON_Delete(jsonAudio);
         }
         else {
-          switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "(%u) processIncomingMessage - missing data payload in playAudio request\n", tech_pvt->id); 
+          switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "(%u) processIncomingMessage - missing data payload in playAudio request\n", tech_pvt->id);
         }
       }
       else if (0 == type.compare("killAudio")) {
@@ -147,12 +147,12 @@ namespace {
         free(jsonString);
       }
       else {
-        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "(%u) processIncomingMessage - unsupported msg type %s\n", tech_pvt->id, type.c_str());  
+        switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "(%u) processIncomingMessage - unsupported msg type %s\n", tech_pvt->id, type.c_str());
       }
       cJSON_Delete(json);
     }
     else {
-      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "(%u) processIncomingMessage - could not parse message: %s\n", tech_pvt->id, message);
+      switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "(%u) processIncomingMessage - could not parse message: %s\n", tech_pvt->id, message);
     }
   }
 
@@ -268,7 +268,18 @@ namespace {
   }
 
   void destroy_tech_pvt(private_t* tech_pvt) {
-    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "%s (%u) destroy_tech_pvt\n", tech_pvt->sessionId, tech_pvt->id);
+    /* destroy_tech_pvt is called from contexts where the
+     * switch_core_session_t* may already be in teardown (post-
+     * media-bug-detach), so we don't take it as a parameter and
+     * can't use SESSION_LOG. tech_pvt->sessionId is the channel
+     * UUID stashed at fork_session_init time and remains valid
+     * for the lifetime of the tech_pvt struct.
+     *
+     * Drop the leading "%s " from the format string — UUID_LOG
+     * prefixes the syslog line with the UUID via mod_syslog's
+     * "%s %s" handler, so leaving sessionId in the message text
+     * would double-prefix every line. */
+    switch_log_printf(SWITCH_CHANNEL_UUID_LOG(tech_pvt->sessionId), SWITCH_LOG_INFO, "(%u) destroy_tech_pvt\n", tech_pvt->id);
     if (tech_pvt->resampler) {
       speex_resampler_destroy(tech_pvt->resampler);
       tech_pvt->resampler = nullptr;
@@ -301,15 +312,15 @@ extern "C" {
     int flags = LCCSCF_USE_SSL;
     
     if (switch_true(switch_channel_get_variable(channel, "MOD_AUDIO_FORK_ALLOW_SELFSIGNED"))) {
-      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "parse_ws_uri - allowing self-signed certs\n");
+      switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_DEBUG, "parse_ws_uri - allowing self-signed certs\n");
       flags |= LCCSCF_ALLOW_SELFSIGNED;
     }
     if (switch_true(switch_channel_get_variable(channel, "MOD_AUDIO_FORK_SKIP_SERVER_CERT_HOSTNAME_CHECK"))) {
-      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "parse_ws_uri - skipping hostname check\n");
+      switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_DEBUG, "parse_ws_uri - skipping hostname check\n");
       flags |= LCCSCF_SKIP_SERVER_CERT_HOSTNAME_CHECK;
     }
     if (switch_true(switch_channel_get_variable(channel, "MOD_AUDIO_FORK_ALLOW_EXPIRED"))) {
-      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "parse_ws_uri - allowing expired certs\n");
+      switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_DEBUG, "parse_ws_uri - allowing expired certs\n");
       flags |= LCCSCF_ALLOW_EXPIRED;
     }
 
@@ -336,7 +347,7 @@ extern "C" {
       *pPort = 80;
     }
     else {
-      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "parse_ws_uri - error parsing uri %s: invalid scheme\n", szServerUri);;
+      switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_NOTICE, "parse_ws_uri - error parsing uri %s: invalid scheme\n", szServerUri);
       return 0;
     }
 
@@ -346,7 +357,7 @@ extern "C" {
     if(std::regex_search(strHost, matches, re)) {
       /*
       for (int i = 0; i < matches.length(); i++) {
-        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "parse_ws_uri - %d: %s\n", i, matches[i].str().c_str());
+        switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_NOTICE, "parse_ws_uri - %d: %s\n", i, matches[i].str().c_str());
       }
       */
       strncpy(host, matches[1].str().c_str(), MAX_WS_URL_LEN);
@@ -360,10 +371,10 @@ extern "C" {
         strcpy(path, "/");
       }
     } else {
-      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "parse_ws_uri - invalid format %s\n", strHost.c_str());
+      switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_NOTICE, "parse_ws_uri - invalid format %s\n", strHost.c_str());
       return 0;
     }
-    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "parse_ws_uri - host %s, path %s\n", host, path);
+    switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_DEBUG, "parse_ws_uri - host %s, path %s\n", host, path);
 
     return 1;
   }

--- a/modules/mod_audio_fork/lws_glue.cpp
+++ b/modules/mod_audio_fork/lws_glue.cpp
@@ -211,10 +211,14 @@ namespace {
               // The AudioPipe is NOT cleared here; it stays valid until the reaper
               // deletes it during cleanup. fork_frame gates on the connection state,
               // so it will not use a failed pipe.
+              /* lws passes a NULL error string for some connect failures (the
+                 AudioPipe forwards its `in` pointer as-is); streaming NULL into
+                 an ostream or %s is undefined behavior */
+              const char* reason = message ? message : "unknown";
               std::stringstream json;
-              json << "{\"reason\":\"" << message << "\"}";
+              json << "{\"reason\":\"" << reason << "\"}";
               tech_pvt->responseHandler(session, EVENT_CONNECT_FAIL, (char *) json.str().c_str());
-              switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "connection failed: %s\n", message);
+              switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "connection failed: %s\n", reason);
             }
             break;
             case AudioPipe::CONNECTION_DROPPED:

--- a/modules/mod_audio_fork/lws_glue.cpp
+++ b/modules/mod_audio_fork/lws_glue.cpp
@@ -306,9 +306,8 @@ namespace {
 
 extern "C" {
   int parse_ws_uri(switch_channel_t *channel, const char* szServerUri, char* host, char *path, unsigned int* pPort, int* pSslFlags) {
-    int i = 0, offset;
+    int offset;
     char server[MAX_WS_URL_LEN + MAX_PATH_LEN];
-    char *saveptr;
     int flags = LCCSCF_USE_SSL;
     
     if (switch_true(switch_channel_get_variable(channel, "MOD_AUDIO_FORK_ALLOW_SELFSIGNED"))) {
@@ -409,11 +408,9 @@ extern "C" {
               int sslFlags,
               int channels,
               char *bugname,
-              char* metadata, 
+              char* metadata,
               void **ppUserData)
-  {    	
-    int err;
-
+  {
     // allocate per-session data structure
     private_t* tech_pvt = (private_t *) switch_core_session_alloc(session, sizeof(private_t));
     if (!tech_pvt) {
@@ -536,9 +533,6 @@ extern "C" {
 
   switch_bool_t fork_frame(switch_core_session_t *session, switch_media_bug_t *bug) {
     private_t* tech_pvt = (private_t*) switch_core_media_bug_get_user_data(bug);
-    size_t inuse = 0;
-    bool dirty = false;
-    char *p = (char *) "{\"msg\": \"buffer overrun\"}";
 
     if (!tech_pvt || tech_pvt->audio_paused || tech_pvt->graceful_shutdown) return SWITCH_TRUE;
     
@@ -581,7 +575,6 @@ extern "C" {
             pAudioPipe->binaryWritePtrAdd(frame.datalen);
             frame.buflen = available = pAudioPipe->binarySpaceAvailable();
             frame.data = pAudioPipe->binaryWritePtr();
-            dirty = true;
           }
         }
       }
@@ -606,7 +599,6 @@ extern "C" {
               size_t bytes_written = out_len << tech_pvt->channels;
               pAudioPipe->binaryWritePtrAdd(bytes_written);
               available = pAudioPipe->binarySpaceAvailable();
-              dirty = true;
             }
             if (available < pAudioPipe->binaryMinSpace()) {
               if (!tech_pvt->buffer_overrun_notified) {

--- a/modules/mod_audio_fork/lws_glue.cpp
+++ b/modules/mod_audio_fork/lws_glue.cpp
@@ -22,6 +22,29 @@
 #define FRAME_SIZE_8000  320 /*which means each 20ms frame as 320 bytes at 8 khz (1 channel only)*/
 
 namespace {
+  /* RAII guard for switch_core_session_locate / switch_core_session_rwunlock.
+     Locates on construction; rwunlocks on destruction so every exit path releases
+     the read lock. Behavior is identical to the manual locate/unlock pattern. */
+  struct SessionLock {
+    switch_core_session_t* session;
+    explicit SessionLock(const char* uuid) : session(switch_core_session_locate(uuid)) {}
+    ~SessionLock() { if (session) switch_core_session_rwunlock(session); }
+    SessionLock(const SessionLock&) = delete;
+    SessionLock& operator=(const SessionLock&) = delete;
+  };
+
+  /* RAII unlock guard for switch_mutex_t. It does NOT acquire the lock: it adopts
+     an already-held mutex (e.g. one taken via switch_mutex_trylock) and unlocks it
+     on every exit path so a locked region cannot leak the mutex on an early return.
+     Trylock semantics at the call site are preserved exactly. */
+  struct MutexUnlockGuard {
+    switch_mutex_t* mutex;
+    explicit MutexUnlockGuard(switch_mutex_t* m) : mutex(m) {}
+    ~MutexUnlockGuard() { switch_mutex_unlock(mutex); }
+    MutexUnlockGuard(const MutexUnlockGuard&) = delete;
+    MutexUnlockGuard& operator=(const MutexUnlockGuard&) = delete;
+  };
+
   static const char *requestedBufferSecs = std::getenv("MOD_AUDIO_FORK_BUFFER_SECS");
   static int nAudioBufferSecs = std::max(1, std::min(requestedBufferSecs ? ::atoi(requestedBufferSecs) : 2, 5));
   static const char *requestedNumServiceThreads = std::getenv("MOD_AUDIO_FORK_SERVICE_THREADS");
@@ -48,7 +71,7 @@ namespace {
           const char* szAudioContentType = cJSON_GetObjectCstr(jsonData, "audioContentType");
           char fileType[6];
           int sampleRate = 16000;
-          if (0 == strcmp(szAudioContentType, "raw")) {
+          if (szAudioContentType && 0 == strcmp(szAudioContentType, "raw")) {
             cJSON* jsonSR = cJSON_GetObjectItem(jsonData, "sampleRate");
             sampleRate = jsonSR && jsonSR->valueint ? jsonSR->valueint : 0;
 
@@ -76,12 +99,12 @@ namespace {
                 break;
             }
           }
-          else if (0 == strcmp(szAudioContentType, "wave") || 0 == strcmp(szAudioContentType, "wav")) {
+          else if (szAudioContentType && (0 == strcmp(szAudioContentType, "wave") || 0 == strcmp(szAudioContentType, "wav"))) {
             strcpy(fileType, ".wav");
           }
           else {
             validAudio = 0;
-            switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "(%u) processIncomingMessage - unsupported audioContentType: %s\n", tech_pvt->id, szAudioContentType);
+            switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "(%u) processIncomingMessage - unsupported audioContentType: %s\n", tech_pvt->id, szAudioContentType ? szAudioContentType : "(null)");
           }
 
           if (validAudio) {
@@ -157,7 +180,8 @@ namespace {
   }
 
   static void eventCallback(const char* sessionId, const char* bugname, AudioPipe::NotifyEvent_t event, const char* message) {
-    switch_core_session_t* session = switch_core_session_locate(sessionId);
+    SessionLock sl(sessionId);
+    switch_core_session_t* session = sl.session;
     if (session) {
       switch_channel_t *channel = switch_core_session_get_channel(session);
       switch_media_bug_t *bug = (switch_media_bug_t*) switch_channel_get_private(channel, bugname);
@@ -201,7 +225,7 @@ namespace {
           }
         }
       }
-      switch_core_session_rwunlock(session);
+      /* sl rwunlocks the session here as it goes out of scope */
     }
   }
   switch_status_t fork_data_init(private_t *tech_pvt, switch_core_session_t *session, char * host, 
@@ -216,7 +240,8 @@ namespace {
 
     switch_core_session_get_read_impl(session, &read_impl);
   
-    if (username = switch_channel_get_variable(channel, "MOD_AUDIO_BASIC_AUTH_USERNAME")) {
+    username = switch_channel_get_variable(channel, "MOD_AUDIO_BASIC_AUTH_USERNAME");
+    if (username) {
       password = switch_channel_get_variable(channel, "MOD_AUDIO_BASIC_AUTH_PASSWORD");
     }
 
@@ -298,7 +323,6 @@ namespace {
       case LLL_WARN: llevel = SWITCH_LOG_WARNING; break;
       case LLL_NOTICE: llevel = SWITCH_LOG_NOTICE; break;
       case LLL_INFO: llevel = SWITCH_LOG_INFO; break;
-      break;
     }
 	  switch_log_printf(SWITCH_CHANNEL_LOG, llevel, "%s\n", line);
   }
@@ -324,7 +348,12 @@ extern "C" {
     }
 
     // get the scheme
-    strncpy(server, szServerUri, MAX_WS_URL_LEN + MAX_PATH_LEN);
+    if (strlen(szServerUri) >= sizeof(server)) {
+      switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(channel), SWITCH_LOG_NOTICE, "parse_ws_uri - error parsing uri: too long (max %lu)\n", sizeof(server) - 1);
+      return 0;
+    }
+    strncpy(server, szServerUri, sizeof(server) - 1);
+    server[sizeof(server) - 1] = '\0';
     if (0 == strncmp(server, "https://", 8) || 0 == strncmp(server, "HTTPS://", 8)) {
       *pSslFlags = flags;
       offset = 8;
@@ -537,13 +566,13 @@ extern "C" {
     if (!tech_pvt || tech_pvt->audio_paused || tech_pvt->graceful_shutdown) return SWITCH_TRUE;
     
     if (switch_mutex_trylock(tech_pvt->mutex) == SWITCH_STATUS_SUCCESS) {
+      /* lock already acquired via trylock above; guard unlocks it on every exit path */
+      MutexUnlockGuard mlk(tech_pvt->mutex);
       if (!tech_pvt->pAudioPipe) {
-        switch_mutex_unlock(tech_pvt->mutex);
         return SWITCH_TRUE;
       }
       AudioPipe *pAudioPipe = static_cast<AudioPipe *>(tech_pvt->pAudioPipe);
       if (pAudioPipe->getLwsState() != AudioPipe::LWS_CLIENT_CONNECTED) {
-        switch_mutex_unlock(tech_pvt->mutex);
         return SWITCH_TRUE;
       }
 
@@ -596,7 +625,7 @@ extern "C" {
 
             if (out_len > 0) {
               // bytes written = num samples * 2 * num channels
-              size_t bytes_written = out_len << tech_pvt->channels;
+              size_t bytes_written = out_len * 2 * tech_pvt->channels;
               pAudioPipe->binaryWritePtrAdd(bytes_written);
               available = pAudioPipe->binarySpaceAvailable();
             }
@@ -614,7 +643,7 @@ extern "C" {
       }
 
       pAudioPipe->unlockAudioBuffer();
-      switch_mutex_unlock(tech_pvt->mutex);
+      /* mlk unlocks tech_pvt->mutex here as it goes out of scope */
     }
     return SWITCH_TRUE;
   }

--- a/modules/mod_audio_fork/lws_glue.cpp
+++ b/modules/mod_audio_fork/lws_glue.cpp
@@ -52,7 +52,7 @@ namespace {
   static const char* mySubProtocolName = std::getenv("MOD_AUDIO_FORK_SUBPROTOCOL_NAME") ?
     std::getenv("MOD_AUDIO_FORK_SUBPROTOCOL_NAME") : "audio.drachtio.org";
   static unsigned int nServiceThreads = std::max(1, std::min(requestedNumServiceThreads ? ::atoi(requestedNumServiceThreads) : 1, 5));
-  static unsigned int idxCallCount = 0;
+  static std::atomic<unsigned int> idxCallCount{0};
   static uint32_t playCount = 0;
 
   void processIncomingMessage(private_t* tech_pvt, switch_core_session_t* session, const char* message) {
@@ -122,8 +122,15 @@ namespace {
             struct playout* playout = (struct playout *) malloc(sizeof(struct playout));
             playout->file = (char *) malloc(strlen(szFilePath) + 1);
             strcpy(playout->file, szFilePath);
+            // The playout list is freed by fork_session_cleanup (API thread) under
+            // tech_pvt->mutex; this append runs on the lws service thread. Guard the
+            // list mutation with the same mutex so the linked list never races.
+            // Lock order is session-rwlock (held via SessionLock) -> tech_pvt->mutex,
+            // identical to the cleanup path, so no deadlock cycle is introduced.
+            switch_mutex_lock(tech_pvt->mutex);
             playout->next = tech_pvt->playout;
             tech_pvt->playout = playout;
+            switch_mutex_unlock(tech_pvt->mutex);
 
             jsonFile = cJSON_CreateString(szFilePath);
             cJSON_AddItemToObject(jsonData, "file", jsonFile);

--- a/modules/mod_audio_fork/lws_glue.cpp
+++ b/modules/mod_audio_fork/lws_glue.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <mutex>
 #include <thread>
+#include <memory>
 #include <list>
 #include <algorithm>
 #include <functional>
@@ -200,23 +201,22 @@ namespace {
             break;
             case AudioPipe::CONNECT_FAIL:
             {
-              // first thing: we can no longer access the AudioPipe
+              // The AudioPipe is NOT cleared here; it stays valid until the reaper
+              // deletes it during cleanup. fork_frame gates on the connection state,
+              // so it will not use a failed pipe.
               std::stringstream json;
               json << "{\"reason\":\"" << message << "\"}";
-              tech_pvt->pAudioPipe = nullptr;
               tech_pvt->responseHandler(session, EVENT_CONNECT_FAIL, (char *) json.str().c_str());
               switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "connection failed: %s\n", message);
             }
             break;
             case AudioPipe::CONNECTION_DROPPED:
-              // first thing: we can no longer access the AudioPipe
-              tech_pvt->pAudioPipe = nullptr;
+              // pipe stays valid until the reaper; fork_frame gates on state.
               tech_pvt->responseHandler(session, EVENT_DISCONNECT, NULL);
               switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "connection dropped from far end\n");
             break;
             case AudioPipe::CONNECTION_CLOSED_GRACEFULLY:
-              // first thing: we can no longer access the AudioPipe
-              tech_pvt->pAudioPipe = nullptr;
+              // pipe stays valid until the reaper; fork_frame gates on state.
               switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "connection closed gracefully\n");
             break;
             case AudioPipe::MESSAGE:
@@ -292,7 +292,37 @@ namespace {
     return SWITCH_STATUS_SUCCESS;
   }
 
+  // Hand the AudioPipe off to a detached thread that closes the connection,
+  // waits for the lws CLOSED to be signalled, then deletes it (via the
+  // shared_ptr destructor). Must be called with tech_pvt->mutex held and only
+  // after the media bug has been removed, so no media-bug thread can still touch
+  // the pipe. sessionId/id are captured BY VALUE so the thread never dereferences
+  // tech_pvt after this returns (tech_pvt lives in the session pool and may be
+  // freed once the session tears down).
+  static void reaper(private_t *tech_pvt) {
+    std::shared_ptr<AudioPipe> pAp((AudioPipe *) tech_pvt->pAudioPipe);
+    tech_pvt->pAudioPipe = nullptr;
+
+    std::string sessionId(tech_pvt->sessionId);
+    uint32_t id = tech_pvt->id;
+    std::thread t([pAp, sessionId, id] {
+      pAp->close();         // no-op unless still connected
+      pAp->waitForClose();  // block until the lws CLOSED/FAIL is signalled
+      switch_log_printf(SWITCH_CHANNEL_UUID_LOG(sessionId.c_str()), SWITCH_LOG_DEBUG,
+        "(%u) audio pipe closed and reaped\n", id);
+      // pAp goes out of scope here -> AudioPipe deleted
+    });
+    t.detach();
+  }
+
   void destroy_tech_pvt(private_t* tech_pvt) {
+    // Safety net for paths that never reached the reaper (e.g. an init error
+    // after the AudioPipe was created but before it ever connected). If the
+    // reaper ran, tech_pvt->pAudioPipe is already null and this is a no-op.
+    if (tech_pvt->pAudioPipe) {
+      delete (AudioPipe *) tech_pvt->pAudioPipe;
+      tech_pvt->pAudioPipe = nullptr;
+    }
     /* destroy_tech_pvt is called from contexts where the
      * switch_core_session_t* may already be in teardown (post-
      * media-bug-detach), so we don't take it as a parameter and
@@ -502,7 +532,10 @@ extern "C" {
     }
 
     if (pAudioPipe && text) pAudioPipe->bufferForSending(text);
-    if (pAudioPipe) pAudioPipe->close();
+    // The media bug has been removed above, so fork_frame can no longer run.
+    // Hand the pipe to the reaper, which closes it, waits for the socket to
+    // actually close, then deletes it — no in-callback delete, no use-after-free.
+    if (pAudioPipe) reaper(tech_pvt);
 
     destroy_tech_pvt(tech_pvt);
     switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "(%u) fork_session_cleanup: connection closed\n", id);

--- a/modules/mod_audio_fork/mod_audio_fork.c
+++ b/modules/mod_audio_fork/mod_audio_fork.c
@@ -170,7 +170,6 @@ SWITCH_STANDARD_API(fork_function)
 	if (!zstr(cmd) && (mycmd = strdup(cmd))) {
 		argc = switch_separate_string(mycmd, ' ', argv, (sizeof(argv) / sizeof(argv[0])));
 	}
-	assert(cmd);
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "mod_audio_fork cmd: %s\n", cmd);
 
 

--- a/modules/mod_audio_fork/mod_audio_fork.h
+++ b/modules/mod_audio_fork/mod_audio_fork.h
@@ -7,6 +7,10 @@
 
 #include <unistd.h>
 
+#ifdef __cplusplus
+#include <atomic>
+#endif
+
 #define MY_BUG_NAME "audio_fork"
 #define MAX_BUG_LEN (64)
 #define MAX_SESSION_ID (256)
@@ -49,8 +53,20 @@ struct private_data {
   int  channels;
   unsigned int id;
   int buffer_overrun_notified:1;
-  int audio_paused:1;
-  int graceful_shutdown:1;
+  /* audio_paused and graceful_shutdown are read on the media-bug (fork_frame)
+     thread and written on the API command thread, with no common lock at the
+     read site (the read happens before fork_frame's trylock). Make them atomic
+     so the cross-thread read/write does not race. They are touched ONLY from
+     C++ (lws_glue.cpp); mod_audio_fork.c never references them, so std::atomic<int>
+     (layout-compatible with int) is ABI-safe for the C side of this shared struct.
+     These cannot be :1 bitfields because std::atomic requires a full object. */
+#ifdef __cplusplus
+  std::atomic<int> audio_paused;
+  std::atomic<int> graceful_shutdown;
+#else
+  int audio_paused;
+  int graceful_shutdown;
+#endif
   char initialMetadata[8192];
 };
 

--- a/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
+++ b/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
@@ -148,32 +148,45 @@ public:
 
     auto OnStreamReady = [this](Model::AudioStream& stream)
     {
-			SessionLock psession(m_sessionId.c_str());
-			if (psession) {
-				m_pStream = &stream;
-				m_connected = true;
+			{
+				SessionLock psession(m_sessionId.c_str());
+				if (psession) {
+					m_pStream = &stream;
+					m_connected = true;
 
 
-				/* Drain the prebuffer under m_audioBufferMutex (guards m_audioBuffer
-				   only). m_connected is already true above, so write() below takes the
-				   connected path and never re-enters the add()/m_audioBufferMutex path
-				   -- so calling write() while holding this lock is safe even though
-				   std::mutex is non-recursive. write() takes m_mutex (not this lock),
-				   giving a one-way ordering m_audioBufferMutex -> m_mutex (no cycle). */
-				std::lock_guard<std::mutex> lk(m_audioBufferMutex);
-				// send any buffered audio
-				int nFrames = m_audioBuffer.getNumItems();
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p got stream ready, %d buffered frames\n", this, nFrames);
-				if (nFrames) {
-					char *p;
-					do {
-						p = m_audioBuffer.getNextChunk();
-						if (p) {
-							write(p, CHUNKSIZE);
-						}
-					} while (p);
+					/* Drain the prebuffer under m_audioBufferMutex (guards m_audioBuffer
+					   only). m_connected is already true above, so write() below takes the
+					   connected path and never re-enters the add()/m_audioBufferMutex path
+					   -- so calling write() while holding this lock is safe even though
+					   std::mutex is non-recursive. write() takes m_mutex (not this lock),
+					   giving a one-way ordering m_audioBufferMutex -> m_mutex (no cycle). */
+					std::lock_guard<std::mutex> lk(m_audioBufferMutex);
+					// send any buffered audio
+					int nFrames = m_audioBuffer.getNumItems();
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p got stream ready, %d buffered frames\n", this, nFrames);
+					if (nFrames) {
+						char *p;
+						do {
+							p = m_audioBuffer.getNextChunk();
+							if (p) {
+								write(p, CHUNKSIZE);
+							}
+						} while (p);
+					}
+				}
+				else {
+					/* session already gone: still publish the stream so the worker's
+					   shutdown path can Close() it -- a finish() issued during the
+					   connect window otherwise has nothing to close and the worker
+					   would sit on the SDK's own (long) timeout */
+					m_pStream = &stream;
 				}
 			}
+			/* wake the worker: it may be blocked in its shutdown wait for the
+			   stream to become available (finish() raced the async connect) */
+			std::lock_guard<std::mutex> lk(m_mutex);
+			m_cond.notify_one();
     };
     auto OnResponseCallback = [this](const TranscribeStreamingServiceClient* pClient, 
 			const Model::StartStreamTranscriptionRequest& request, 
@@ -280,13 +293,25 @@ public:
 		bool shutdownInitiated = false;
 		while (true) {
 			std::unique_lock<std::mutex> lk(m_mutex);
-			m_cond.wait(lk, [&, this] { 
-				return (!m_deqAudio.empty() && !m_finishing)  || m_transcript.TranscriptHasBeenSet() || m_finished  || (m_finishing && !shutdownInitiated);
+			m_cond.wait(lk, [&, this] {
+				return (!m_deqAudio.empty() && !m_finishing)  || m_transcript.TranscriptHasBeenSet() || m_finished  || (m_finishing && !shutdownInitiated) ||
+					(m_finishing && shutdownInitiated && nullptr != m_pStream.load());
 			});
 
 
-			// we have data to process or have been told we're done
-			if (m_finished || !m_connected) return;
+			// terminal: the SDK delivered its final outcome; no callbacks remain in flight
+			if (m_finished) return;
+			/* Never-connected AND not connecting (VAD armed, no speech seen):
+			   nothing is outstanding, safe to exit and let the caller delete this
+			   object. If a connect IS in flight (m_connecting) we must NOT return:
+			   the caller deletes this object on return while the SDK still holds
+			   this-capturing callbacks (OnStreamReady/OnResponseCallback) -- a
+			   use-after-free on an SDK thread. Stay in the loop: once the stream
+			   becomes ready the shutdown branch below Close()s it, the SDK then
+			   delivers the final outcome (OnResponseCallback sets m_finished), and
+			   only then do we return. A failed connect delivers the error outcome
+			   the same way. */
+			if (!m_connected && !m_connecting) return;
 
 			if (m_transcript.TranscriptHasBeenSet()) {
 				SessionLock psession(m_sessionId.c_str());

--- a/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
+++ b/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
@@ -75,6 +75,7 @@ public:
 	 		m_packets(0), m_responseHandler(responseHandler), m_pStream(nullptr),
 			m_maxBufferedFrames(DEFAULT_MAX_BUFFERED_FRAMES), m_droppedAudioWarned(false),
 			/* prebuffer up to 15 chunks (CHUNKSIZE bytes for 8kHz, 2x for resampled 16kHz) until the stream is connected */
+			m_prebufChunkSize(CHUNKSIZE * (samples_per_second == 8000 ? 1 : 2)),
 			m_audioBuffer(CHUNKSIZE * (samples_per_second == 8000 ? 1 : 2), 15) {
 		/* allow operators to tune the back-pressure buffer cap via env var */
 		const char* maxFramesEnv = std::getenv("AWS_TRANSCRIBE_MAX_BUFFERED_FRAMES");
@@ -170,7 +171,11 @@ public:
 						do {
 							p = m_audioBuffer.getNextChunk();
 							if (p) {
-								write(p, CHUNKSIZE);
+								/* chunks are m_prebufChunkSize bytes (640 when resampling
+								   to 16k) -- draining CHUNKSIZE (320) sent only the first
+								   half of every prebuffered frame, garbling the leading
+								   audio of every resampled call */
+								write(p, m_prebufChunkSize);
 							}
 						} while (p);
 					}
@@ -407,6 +412,7 @@ private:
 	   despite std::mutex being non-recursive. Ordering is one-way
 	   (m_audioBufferMutex -> m_mutex), never the reverse, so there is no cycle. */
 	std::mutex m_audioBufferMutex;
+	uint32_t m_prebufChunkSize;     /* byte size of each m_audioBuffer chunk */
 	SimpleBuffer m_audioBuffer;
 };
 

--- a/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
+++ b/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
@@ -181,6 +181,14 @@ public:
 							}
 						} while (p);
 					}
+					if (!m_prebufStaging.empty()) {
+						/* flush the sub-chunk staging remainder, in order */
+						Aws::Vector<unsigned char> bits { m_prebufStaging.begin(), m_prebufStaging.end() };
+						std::lock_guard<std::mutex> lk2(m_mutex);
+						m_deqAudio.push_back(std::move(bits));
+					}
+					m_prebufStaging.clear();
+					m_prebufStaging.shrink_to_fit();
 					m_connected = true;
 				}
 				else {
@@ -256,9 +264,19 @@ public:
          the drain: enqueued ahead of older prebuffered audio, or added to the
          prebuffer after its one-shot drain and stranded forever. */
       if (!m_connected) {
-        if (datalen % CHUNKSIZE == 0) {
-          switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer::write queuing %d bytes\n", datalen);
-          m_audioBuffer.add(data, datalen);
+        /* SimpleBuffer stores fixed m_prebufChunkSize slices and its add()
+           rejects other lengths. The old gate (datalen % CHUNKSIZE) dropped
+           non-multiple frames wholesale (30ms-ptime codecs, resampler
+           output) -- and for resampled sessions it even let 320-byte frames
+           through to an add() sliced at 640 that silently rejected them, so
+           ALL pre-connect audio was lost. Stage bytes and feed whole chunks;
+           the sub-chunk remainder is flushed at drain time. */
+        const unsigned char* p = static_cast<const unsigned char*>(data);
+        m_prebufStaging.insert(m_prebufStaging.end(), p, p + datalen);
+        size_t usable = (m_prebufStaging.size() / m_prebufChunkSize) * m_prebufChunkSize;
+        if (usable) {
+          m_audioBuffer.add(m_prebufStaging.data(), (uint32_t) usable);
+          m_prebufStaging.erase(m_prebufStaging.begin(), m_prebufStaging.begin() + usable);
         }
         return true;
       }
@@ -438,6 +456,8 @@ private:
 	std::mutex m_audioBufferMutex;
 	uint32_t m_prebufChunkSize;     /* byte size of each m_audioBuffer chunk */
 	SimpleBuffer m_audioBuffer;
+	/* sub-chunk staging for the pre-connect path; guarded by m_audioBufferMutex */
+	std::vector<unsigned char> m_prebufStaging;
 };
 
 static void *SWITCH_THREAD_FUNC aws_transcribe_thread(switch_thread_t *thread, void *obj) {

--- a/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
+++ b/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
@@ -153,17 +153,17 @@ public:
 				SessionLock psession(m_sessionId.c_str());
 				if (psession) {
 					m_pStream = &stream;
-					m_connected = true;
 
-
-					/* Drain the prebuffer under m_audioBufferMutex (guards m_audioBuffer
-					   only). m_connected is already true above, so write() below takes the
-					   connected path and never re-enters the add()/m_audioBufferMutex path
-					   -- so calling write() while holding this lock is safe even though
-					   std::mutex is non-recursive. write() takes m_mutex (not this lock),
-					   giving a one-way ordering m_audioBufferMutex -> m_mutex (no cycle). */
+					/* Drain the prebuffer and only THEN publish m_connected, all under
+					   m_audioBufferMutex. write()'s pre-connect path re-checks
+					   m_connected under this same lock, so a media frame can neither
+					   jump ahead of older prebuffered audio into the deque (reorder)
+					   nor land in the prebuffer after this one-shot drain (stranded
+					   forever). Chunks are enqueued directly -- calling write() here
+					   would take the pre-connect path (m_connected still false) and
+					   self-deadlock on this non-recursive mutex. Lock order stays the
+					   documented one-way m_audioBufferMutex -> m_mutex. */
 					std::lock_guard<std::mutex> lk(m_audioBufferMutex);
-					// send any buffered audio
 					int nFrames = m_audioBuffer.getNumItems();
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p got stream ready, %d buffered frames\n", this, nFrames);
 					if (nFrames) {
@@ -171,14 +171,17 @@ public:
 						do {
 							p = m_audioBuffer.getNextChunk();
 							if (p) {
-								/* chunks are m_prebufChunkSize bytes (640 when resampling
-								   to 16k) -- draining CHUNKSIZE (320) sent only the first
-								   half of every prebuffered frame, garbling the leading
-								   audio of every resampled call */
-								write(p, m_prebufChunkSize);
+								/* m_prebufChunkSize bytes per chunk (640 when resampling
+								   to 16k): draining a fixed CHUNKSIZE sent only the first
+								   half of every prebuffered frame */
+								const unsigned char* beg = reinterpret_cast<const unsigned char*>(p);
+								Aws::Vector<unsigned char> bits { beg, beg + m_prebufChunkSize };
+								std::lock_guard<std::mutex> lk2(m_mutex);
+								m_deqAudio.push_back(std::move(bits));
 							}
 						} while (p);
 					}
+					m_connected = true;
 				}
 				else {
 					/* session already gone: still publish the stream so the worker's
@@ -240,15 +243,22 @@ public:
 			return false;
 		}
     if (!m_connected) {
-      if (datalen % CHUNKSIZE == 0) {
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer::write queuing %d bytes\n", datalen);
-        /* guard m_audioBuffer against the SDK-IO drain in OnStreamReady. Hold
-           ONLY m_audioBufferMutex here (never m_mutex), so the pre-connect add
-           path and the drain order one-way (m_audioBufferMutex -> m_mutex). */
-        std::lock_guard<std::mutex> lk(m_audioBufferMutex);
-        m_audioBuffer.add(data, datalen);
+      std::lock_guard<std::mutex> lk(m_audioBufferMutex);
+      /* re-check under the lock: OnStreamReady publishes m_connected only
+         AFTER draining the prebuffer while holding this same mutex -- so from
+         here we are either strictly before the drain (buffer the frame; the
+         drain will pick it up in order) or strictly after it (fall through to
+         the deque path). Checking the flag outside the lock let a frame race
+         the drain: enqueued ahead of older prebuffered audio, or added to the
+         prebuffer after its one-shot drain and stranded forever. */
+      if (!m_connected) {
+        if (datalen % CHUNKSIZE == 0) {
+          switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer::write queuing %d bytes\n", datalen);
+          m_audioBuffer.add(data, datalen);
+        }
+        return true;
       }
-      return true;
+      /* connected while acquiring the lock: fall through to the deque path */
     }
 
 		/* HOT PATH: do the heap allocation + copy of the frame BEFORE taking

--- a/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
+++ b/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
@@ -365,12 +365,22 @@ public:
 			else {
 				/* load the atomic pointer once into a local before dereferencing */
 				AudioStream* pStream = m_pStream.load();
-				// send out any queued speech packets
-				while (pStream && !m_deqAudio.empty()) {
-					Aws::Vector<unsigned char>& bits = m_deqAudio.front();
+				/* Send queued speech packets WITHOUT holding m_mutex:
+				   WriteAudioEvent can block under HTTP/2 back-pressure, and the
+				   media-bug thread blocks on m_mutex inside write() -- holding the
+				   lock across the writes turned congestion into a media-thread
+				   stall and made the bounded-deque drop-oldest cap unreachable in
+				   exactly the scenario it exists for. Swap the deque into a local
+				   under the lock, then write lock-free; ordering is preserved
+				   (single worker thread, frames swapped out before any new push). */
+				std::deque< Aws::Vector<unsigned char> > local;
+				if (pStream && !m_deqAudio.empty()) local.swap(m_deqAudio);
+				lk.unlock();
+				while (pStream && !local.empty()) {
+					Aws::Vector<unsigned char>& bits = local.front();
 					Aws::TranscribeStreamingService::Model::AudioEvent event(std::move(bits));
 					pStream->WriteAudioEvent(event);
-					m_deqAudio.pop_front();
+					local.pop_front();
 				}
 			}
 		}

--- a/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
+++ b/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
@@ -212,8 +212,12 @@ public:
 					cJSON_AddStringToObject(json, "type", "error");
 					cJSON_AddStringToObject(json, "error", message.c_str());
 					char* jsonString = cJSON_PrintUnformatted(json);
-					m_responseHandler(psession.get(), jsonString, m_bugname.c_str());
-					free(jsonString);
+					/* cJSON_PrintUnformatted returns NULL on allocation failure and the
+					   response handler's first act is strcmp against the payload */
+					if (jsonString) {
+						m_responseHandler(psession.get(), jsonString, m_bugname.c_str());
+						free(jsonString);
+					}
 					cJSON_Delete(json);
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p stream got error response %s : %s\n", this, message.c_str(), exception.c_str());
 				}

--- a/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
+++ b/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
@@ -27,6 +27,12 @@
 /* one audio chunk = 320 bytes = 160 samples (20ms) of 16-bit mono PCM at 8kHz */
 #define CHUNKSIZE (320)
 
+/* Default cap on the number of audio frames buffered in m_deqAudio while the
+   HTTP/2 stream to AWS is back-pressured. Frames arrive every ~20ms, so 500
+   frames is ~10s of audio. Overridable via AWS_TRANSCRIBE_MAX_BUFFERED_FRAMES.
+   When the cap is exceeded we drop the OLDEST queued frame(s) (see write()). */
+#define DEFAULT_MAX_BUFFERED_FRAMES (500)
+
 using namespace Aws;
 using namespace Aws::Utils;
 using namespace Aws::Auth;
@@ -67,8 +73,15 @@ public:
 		responseHandler_t responseHandler
   ) : m_sessionId(sessionId), m_bugname(bugname), m_finished(false), m_interim(interim), m_finishing(false), m_connected(false), m_connecting(false),
 	 		m_packets(0), m_responseHandler(responseHandler), m_pStream(nullptr),
+			m_maxBufferedFrames(DEFAULT_MAX_BUFFERED_FRAMES), m_droppedAudioWarned(false),
 			/* prebuffer up to 15 chunks (CHUNKSIZE bytes for 8kHz, 2x for resampled 16kHz) until the stream is connected */
 			m_audioBuffer(CHUNKSIZE * (samples_per_second == 8000 ? 1 : 2), 15) {
+		/* allow operators to tune the back-pressure buffer cap via env var */
+		const char* maxFramesEnv = std::getenv("AWS_TRANSCRIBE_MAX_BUFFERED_FRAMES");
+		if (maxFramesEnv != nullptr) {
+			long v = atol(maxFramesEnv);
+			if (v > 0) m_maxBufferedFrames = (size_t) v;
+		}
 		Aws::String key(awsAccessKeyId);
 		Aws::String secret(awsSecretAccessKey);
 		Aws::Client::ClientConfiguration config;
@@ -209,15 +222,36 @@ public:
       return true;
     }
 
-		std::lock_guard<std::mutex> lk(m_mutex);
-
+		/* HOT PATH: do the heap allocation + copy of the frame BEFORE taking
+		   m_mutex, so we don't contend with the worker thread while holding the
+		   lock. Under the lock we only do the cap check, deque push and notify. */
 		const auto beg = static_cast<const unsigned char*>(data);
 		const auto end = beg + datalen;
 		Aws::Vector<unsigned char> bits { beg, end };
-		m_deqAudio.push_back(bits);
-		m_packets++;
 
-		m_cond.notify_one();
+		{
+			std::lock_guard<std::mutex> lk(m_mutex);
+
+			/* Bounded buffer (drop-oldest). Under HTTP/2 back-pressure the worker
+			   may not be draining m_deqAudio fast enough; rather than grow without
+			   bound (per-call RAM blow-up / OOM) we drop the OLDEST queued frames.
+			   NOTE: this is INTENTIONALLY behavior-changing -- under sustained
+			   congestion we discard audio instead of buffering it indefinitely. */
+			while (m_deqAudio.size() >= m_maxBufferedFrames) {
+				m_deqAudio.pop_front();
+				if (!m_droppedAudioWarned) {
+					m_droppedAudioWarned = true;
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+						"GStreamer::write %p audio buffer exceeded %zu frames (back-pressure); dropping oldest audio. Tune AWS_TRANSCRIBE_MAX_BUFFERED_FRAMES.\n",
+						this, m_maxBufferedFrames);
+				}
+			}
+
+			m_deqAudio.push_back(std::move(bits));
+			m_packets++;
+
+			m_cond.notify_one();
+		}
 
 		return true;
 	}
@@ -279,18 +313,22 @@ public:
 				shutdownInitiated = true;
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer::writing disconnect event %p\n", this);
 
-				if (m_pStream) {
-					m_pStream->flush();
-					m_pStream->Close();
+				/* load the atomic pointer once into a local before dereferencing */
+				AudioStream* pStream = m_pStream.load();
+				if (pStream) {
+					pStream->flush();
+					pStream->Close();
 					m_pStream = nullptr;
 				}
 			}
 			else {
+				/* load the atomic pointer once into a local before dereferencing */
+				AudioStream* pStream = m_pStream.load();
 				// send out any queued speech packets
-				while (!m_deqAudio.empty()) {
+				while (pStream && !m_deqAudio.empty()) {
 					Aws::Vector<unsigned char>& bits = m_deqAudio.front();
 					Aws::TranscribeStreamingService::Model::AudioEvent event(std::move(bits));
-					m_pStream->WriteAudioEvent(event);
+					pStream->WriteAudioEvent(event);
 					m_deqAudio.pop_front();
 				}
 			}
@@ -306,7 +344,10 @@ private:
 	std::string m_bugname;
 	std::string  m_region;
 	Aws::UniquePtr<TranscribeStreamingServiceClient> m_client;
-	AudioStream* m_pStream;
+	/* written on the AWS SDK IO thread (OnStreamReady) and cleared on the worker
+	   thread; read/dereferenced on the worker thread. atomic so the pointer
+	   publish/clear is race-free without needing m_mutex around the store. */
+	std::atomic<AudioStream*> m_pStream;
 	StartStreamTranscriptionRequest m_request;
 	StartStreamTranscriptionHandler m_handler;
 	TranscriptEvent m_transcript;
@@ -320,6 +361,8 @@ private:
 	std::mutex m_mutex;
 	std::condition_variable m_cond;
 	std::deque< Aws::Vector<unsigned char> > m_deqAudio;
+	size_t m_maxBufferedFrames;      /* cap on m_deqAudio size; drop-oldest beyond this */
+	bool m_droppedAudioWarned;       /* one-shot warning when we first drop audio */
 	SimpleBuffer m_audioBuffer;
 };
 
@@ -564,6 +607,29 @@ extern "C" {
 		return SWITCH_STATUS_FALSE;
 	}
 	
+	void aws_transcribe_session_cleanup(void *pUserData) {
+		struct cap_cb *cb = (struct cap_cb *) pUserData;
+		if (!cb) return;
+
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+			"aws_transcribe_session_cleanup: tearing down orphaned cb %p (media bug never attached)\n", (void *) cb);
+
+		/* signal the worker thread to stop, then join it. The thread deletes the
+		   GStreamer and clears cb->streamer on exit. */
+		GStreamer* streamer = (GStreamer *) cb->streamer;
+		if (streamer) {
+			streamer->finish();
+		}
+		if (cb->thread) {
+			switch_status_t retval;
+			switch_thread_join(&retval, cb->thread);
+			cb->thread = NULL;
+		}
+
+		/* free resampler/vad (and the GStreamer if, defensively, still present) */
+		killcb(cb);
+	}
+
 	switch_bool_t aws_transcribe_frame(switch_media_bug_t *bug, void* user_data) {
 		switch_core_session_t *session = switch_core_media_bug_get_session(bug);
 		uint8_t data[SWITCH_RECOMMENDED_BUFFER_SIZE];

--- a/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
+++ b/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
@@ -154,6 +154,13 @@ public:
 				m_connected = true;
 
 
+				/* Drain the prebuffer under m_audioBufferMutex (guards m_audioBuffer
+				   only). m_connected is already true above, so write() below takes the
+				   connected path and never re-enters the add()/m_audioBufferMutex path
+				   -- so calling write() while holding this lock is safe even though
+				   std::mutex is non-recursive. write() takes m_mutex (not this lock),
+				   giving a one-way ordering m_audioBufferMutex -> m_mutex (no cycle). */
+				std::lock_guard<std::mutex> lk(m_audioBufferMutex);
 				// send any buffered audio
 				int nFrames = m_audioBuffer.getNumItems();
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p got stream ready, %d buffered frames\n", this, nFrames);
@@ -217,6 +224,10 @@ public:
     if (!m_connected) {
       if (datalen % CHUNKSIZE == 0) {
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer::write queuing %d bytes\n", datalen);
+        /* guard m_audioBuffer against the SDK-IO drain in OnStreamReady. Hold
+           ONLY m_audioBufferMutex here (never m_mutex), so the pre-connect add
+           path and the drain order one-way (m_audioBufferMutex -> m_mutex). */
+        std::lock_guard<std::mutex> lk(m_audioBufferMutex);
         m_audioBuffer.add(data, datalen);
       }
       return true;
@@ -363,6 +374,14 @@ private:
 	std::deque< Aws::Vector<unsigned char> > m_deqAudio;
 	size_t m_maxBufferedFrames;      /* cap on m_deqAudio size; drop-oldest beyond this */
 	bool m_droppedAudioWarned;       /* one-shot warning when we first drop audio */
+	/* guards m_audioBuffer ONLY. The media thread (write() -> add()) on the
+	   pre-connect path and the SDK-IO thread (OnStreamReady drain) both touch
+	   the SimpleBuffer cursors; this serializes them. The drain holds this lock
+	   while calling write(), but by then m_connected==true so write() takes the
+	   connected path and never re-enters the add()/buffer-locked path -- safe
+	   despite std::mutex being non-recursive. Ordering is one-way
+	   (m_audioBufferMutex -> m_mutex), never the reverse, so there is no cycle. */
+	std::mutex m_audioBufferMutex;
 	SimpleBuffer m_audioBuffer;
 };
 
@@ -374,21 +393,21 @@ static void *SWITCH_THREAD_FUNC aws_transcribe_thread(switch_thread_t *thread, v
 	GStreamer* pStreamer = new GStreamer(cb->sessionId, cb->bugname, cb->channels, cb->lang, cb->interim, cb->samples_per_second, cb->region, cb->awsAccessKeyId, cb->awsSecretAccessKey,
 		cb->responseHandler);
   if (!cb->vad) pStreamer->connect();
-	cb->streamer = pStreamer;
+	cb->streamer.store(pStreamer);
 	pStreamer->processData(); //blocks until done
 
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "transcribe_thread: stopping cb %p\n", (void *) cb);
 	delete pStreamer;
-	cb->streamer = nullptr;
+	cb->streamer.store(nullptr);
 	return nullptr;
 }
 
 static void killcb(struct cap_cb* cb) {
 	if (cb) {
-		if (cb->streamer) {
-			GStreamer* p = (GStreamer *) cb->streamer;
+		GStreamer* p = (GStreamer *) cb->streamer.load();
+		if (p) {
 			delete p;
-			cb->streamer = nullptr;
+			cb->streamer.store(nullptr);
 		}
 		if (cb->resampler) {
 				speex_resampler_destroy(cb->resampler);
@@ -574,7 +593,7 @@ extern "C" {
 
 			// close connection and get final responses
 			switch_mutex_lock(cb->mutex);
-			GStreamer* streamer = (GStreamer *) cb->streamer;
+			GStreamer* streamer = (GStreamer *) cb->streamer.load();
 			if (streamer) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "aws_transcribe_session_stop: finish..%s\n", bugname);
 				streamer->finish();
@@ -616,7 +635,7 @@ extern "C" {
 
 		/* signal the worker thread to stop, then join it. The thread deletes the
 		   GStreamer and clears cb->streamer on exit. */
-		GStreamer* streamer = (GStreamer *) cb->streamer;
+		GStreamer* streamer = (GStreamer *) cb->streamer.load();
 		if (streamer) {
 			streamer->finish();
 		}
@@ -640,7 +659,7 @@ extern "C" {
 		frame.buflen = SWITCH_RECOMMENDED_BUFFER_SIZE;
 
 		if (switch_mutex_trylock(cb->mutex) == SWITCH_STATUS_SUCCESS) {
-			GStreamer* streamer = (GStreamer *) cb->streamer;
+			GStreamer* streamer = (GStreamer *) cb->streamer.load();
 			if (streamer) {
 				/* resampler output buffer, declared once and reused across loop iterations */
 				spx_int16_t out[SWITCH_RECOMMENDED_BUFFER_SIZE];

--- a/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
+++ b/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
@@ -419,6 +419,12 @@ static void *SWITCH_THREAD_FUNC aws_transcribe_thread(switch_thread_t *thread, v
 		cb->responseHandler);
   if (!cb->vad) pStreamer->connect();
 	cb->streamer.store(pStreamer);
+	/* a stop/hangup may have arrived while the constructor was running: it
+	   found cb->streamer NULL, had nothing to finish(), and is (or will be)
+	   blocked in switch_thread_join. It sets stop_requested BEFORE loading
+	   cb->streamer and we re-check AFTER publishing it, so between the two
+	   orderings the request can never fall through the crack. */
+	if (cb->stop_requested.load()) pStreamer->finish();
 	pStreamer->processData(); //blocks until done
 
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "transcribe_thread: stopping cb %p\n", (void *) cb);
@@ -618,6 +624,9 @@ extern "C" {
 
 			// close connection and get final responses
 			switch_mutex_lock(cb->mutex);
+			/* order matters: set the flag before loading the pointer (the worker
+			   publishes the pointer, then checks the flag) */
+			cb->stop_requested.store(1);
 			GStreamer* streamer = (GStreamer *) cb->streamer.load();
 			if (streamer) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "aws_transcribe_session_stop: finish..%s\n", bugname);
@@ -659,7 +668,9 @@ extern "C" {
 			"aws_transcribe_session_cleanup: tearing down orphaned cb %p (media bug never attached)\n", (void *) cb);
 
 		/* signal the worker thread to stop, then join it. The thread deletes the
-		   GStreamer and clears cb->streamer on exit. */
+		   GStreamer and clears cb->streamer on exit. Flag first, then load: see
+		   aws_transcribe_session_stop. */
+		cb->stop_requested.store(1);
 		GStreamer* streamer = (GStreamer *) cb->streamer.load();
 		if (streamer) {
 			streamer->finish();

--- a/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
+++ b/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <mutex>
 #include <thread>
+#include <chrono>
 #include <condition_variable>
 #include <string>
 #include <sstream>
@@ -328,12 +329,36 @@ public:
 
 	void processData() {
 		bool shutdownInitiated = false;
+		bool requestAborted = false;
 		while (true) {
 			std::unique_lock<std::mutex> lk(m_mutex);
-			m_cond.wait(lk, [&, this] {
+			auto ready = [&, this] {
 				return (!m_deqAudio.empty() && !m_finishing)  || m_transcript.TranscriptHasBeenSet() || m_finished  || (m_finishing && !shutdownInitiated) ||
 					(m_finishing && shutdownInitiated && nullptr != m_pStream.load());
-			});
+			};
+			if (shutdownInitiated) {
+				/* Bounded shutdown: after Close() the final outcome normally
+				   arrives within a second, but on a dead network nothing would
+				   ever wake us. If it is overdue, abort the in-flight HTTP
+				   request -- AWSClient::DisableRequestProcessing() fails the
+				   request at the http-client layer and the SDK then delivers the
+				   error outcome via OnResponseCallback, which sets m_finished
+				   (verified against aws-sdk-cpp source; the client destructor's
+				   RAIICounter wait + executor join back-stop the teardown
+				   regardless). */
+				if (!m_cond.wait_for(lk, std::chrono::seconds(10), ready)) {
+					if (!requestAborted) {
+						requestAborted = true;
+						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							"GStreamer %p final response overdue 10s after shutdown; aborting in-flight request\n", this);
+						m_client->DisableRequestProcessing();
+					}
+					continue;
+				}
+			}
+			else {
+				m_cond.wait(lk, ready);
+			}
 
 
 			// terminal: the SDK delivered its final outcome; no callbacks remain in flight
@@ -484,6 +509,12 @@ static void *SWITCH_THREAD_FUNC aws_transcribe_thread(switch_thread_t *thread, v
 	}
 
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "transcribe_thread: stopping cb %p\n", (void *) cb);
+	/* deleting here is safe even if the SDK's async task is still unwinding
+	   past our OnResponseCallback: ~TranscribeStreamingServiceClient ->
+	   ShutdownSdkClient waits for m_operationsProcessed==0 (the async op holds
+	   an RAIICounter through its full unwind) and then resets the executor,
+	   whose destructor joins any in-flight task thread (verified against
+	   aws-sdk-cpp source: AWSClientAsyncCRTP.h, DefaultExecutor.cpp). */
 	delete pStreamer;
 	cb->streamer.store(nullptr);
 	return nullptr;

--- a/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
+++ b/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
@@ -93,24 +93,26 @@ public:
 
 		const char* var;
 		switch_core_session_t* session = switch_core_session_locate(sessionId);
-    switch_channel_t *channel = switch_core_session_get_channel(session);
+		if (session) {
+			switch_channel_t *channel = switch_core_session_get_channel(session);
 
-		if (var = switch_channel_get_variable(channel, "AWS_SHOW_SPEAKER_LABEL")) {
-			m_request.SetShowSpeakerLabel(true);
+			if (var = switch_channel_get_variable(channel, "AWS_SHOW_SPEAKER_LABEL")) {
+				m_request.SetShowSpeakerLabel(true);
+			}
+			if (var = switch_channel_get_variable(channel, "AWS_ENABLE_CHANNEL_IDENTIFICATION")) {
+				m_request.SetEnableChannelIdentification(true);
+			}
+			if (var = switch_channel_get_variable(channel, "AWS_VOCABULARY_NAME")) {
+				m_request.SetVocabularyName(var);
+			}
+			if (var = switch_channel_get_variable(channel, "AWS_VOCABULARY_FILTER_NAME")) {
+				m_request.SetVocabularyFilterName(var);
+			}
+			if (var = switch_channel_get_variable(channel, "AWS_VOCABULARY_FILTER_METHOD")) {
+				m_request.SetVocabularyFilterMethod(VocabularyFilterMethodMapper::GetVocabularyFilterMethodForName(var));
+			}
+			switch_core_session_rwunlock(session);
 		}
-		if (var = switch_channel_get_variable(channel, "AWS_ENABLE_CHANNEL_IDENTIFICATION")) {
-			m_request.SetEnableChannelIdentification(true);
-		}
-		if (var = switch_channel_get_variable(channel, "AWS_VOCABULARY_NAME")) {
-			m_request.SetVocabularyName(var);
-		}
-		if (var = switch_channel_get_variable(channel, "AWS_VOCABULARY_FILTER_NAME")) {
-			m_request.SetVocabularyFilterName(var);
-		}
-		if (var = switch_channel_get_variable(channel, "AWS_VOCABULARY_FILTER_METHOD")) {
-			m_request.SetVocabularyFilterMethod(VocabularyFilterMethodMapper::GetVocabularyFilterMethodForName(var));
-		}
-    switch_core_session_rwunlock(session);
 	}
 
 	void connect() {
@@ -402,10 +404,16 @@ extern "C" {
 		switch_threadattr_t *thd_attr = NULL;
 		switch_memory_pool_t *pool = switch_core_session_get_pool(session);
 		auto read_codec = switch_core_session_get_read_codec(session);
+		if (!read_codec || !read_codec->implementation) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "no read codec/implementation on session\n");
+			// cannot use 'goto done' here: it would cross the initializations of
+			// sampleRate/cb/etc. (ill-formed in C++); done: only does 'return status'.
+			return SWITCH_STATUS_FALSE;
+		}
 		uint32_t sampleRate = read_codec->implementation->actual_samples_per_second;
 
 		struct cap_cb* cb = (struct cap_cb *) switch_core_session_alloc(session, sizeof(*cb));
-		memset(cb, sizeof(cb), 0);
+		memset(cb, 0, sizeof(*cb));
 		const char* awsAccessKeyId = switch_channel_get_variable(channel, "AWS_ACCESS_KEY_ID");
 		const char* awsSecretAccessKey = switch_channel_get_variable(channel, "AWS_SECRET_ACCESS_KEY");
 		const char* awsRegion = switch_channel_get_variable(channel, "AWS_REGION");
@@ -417,13 +425,18 @@ extern "C" {
 			goto done;
 		}
 		strncpy(cb->sessionId, switch_core_session_get_uuid(session), MAX_SESSION_ID);
+		cb->sessionId[MAX_SESSION_ID-1] = '\0';
 		strncpy(cb->bugname, bugname, MAX_BUG_LEN);
+		cb->bugname[MAX_BUG_LEN-1] = '\0';
 
 		if (awsAccessKeyId && awsSecretAccessKey && awsRegion) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Using channel vars for aws authentication\n");
 			strncpy(cb->awsAccessKeyId, awsAccessKeyId, 128);
+			cb->awsAccessKeyId[128-1] = '\0';
 			strncpy(cb->awsSecretAccessKey, awsSecretAccessKey, 128);
+			cb->awsSecretAccessKey[128-1] = '\0';
 			strncpy(cb->region, awsRegion, MAX_REGION);
+			cb->region[MAX_REGION-1] = '\0';
 
 		}
 		else if (std::getenv("AWS_ACCESS_KEY_ID") &&
@@ -431,8 +444,11 @@ extern "C" {
 			std::getenv("AWS_REGION")) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Using env vars for aws authentication\n");
 			strncpy(cb->awsAccessKeyId, std::getenv("AWS_ACCESS_KEY_ID"), 128);
-			strncpy(cb->awsSecretAccessKey, std::getenv("AWS_SECRET_ACCESS_KEY"), 128);		
+			cb->awsAccessKeyId[128-1] = '\0';
+			strncpy(cb->awsSecretAccessKey, std::getenv("AWS_SECRET_ACCESS_KEY"), 128);
+			cb->awsSecretAccessKey[128-1] = '\0';
 			strncpy(cb->region, std::getenv("AWS_REGION"), MAX_REGION);
+			cb->region[MAX_REGION-1] = '\0';
 		}
 		else {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "No channel vars or env vars for aws authentication..will use default profile if found\n");
@@ -448,6 +464,7 @@ extern "C" {
 
 		cb->interim = interim;
 		strncpy(cb->lang, lang, MAX_LANG);
+		cb->lang[MAX_LANG-1] = '\0';
 		cb->samples_per_second = sampleRate;
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "sample rate of rtp stream is %d\n", samples_per_second);
 		if (sampleRate != 8000) {

--- a/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
+++ b/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
@@ -589,7 +589,9 @@ extern "C" {
 		cb->samples_per_second = sampleRate;
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "sample rate of rtp stream is %d\n", samples_per_second);
 		if (sampleRate != 8000) {
-			cb->resampler = speex_resampler_init(1, sampleRate, 16000, SWITCH_RESAMPLE_QUALITY, &err);
+			/* channels, not 1: stereo capture (SMBF_STEREO) delivers interleaved
+			   2-channel frames and the frame path uses the interleaved API */
+			cb->resampler = speex_resampler_init(cb->channels, sampleRate, 16000, SWITCH_RESAMPLE_QUALITY, &err);
 			if (0 != err) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s: Error initializing resampler: %s.\n", 
 							switch_channel_get_name(channel), speex_resampler_strerror(err));
@@ -727,7 +729,10 @@ extern "C" {
 				spx_int16_t out[SWITCH_RECOMMENDED_BUFFER_SIZE];
 				while (switch_core_media_bug_read(bug, &frame, SWITCH_TRUE) == SWITCH_STATUS_SUCCESS && !switch_test_flag((&frame), SFF_CNG)) {
 					if (frame.datalen) {
-						spx_uint32_t out_len = SWITCH_RECOMMENDED_BUFFER_SIZE;
+						/* interleaved API: capacity and counts are in samples PER
+						   CHANNEL; the out[] array holds SWITCH_RECOMMENDED_BUFFER_SIZE
+						   total elements across channels */
+						spx_uint32_t out_len = SWITCH_RECOMMENDED_BUFFER_SIZE / cb->channels;
 						spx_uint32_t in_len = frame.samples;
 						size_t written;
 
@@ -741,11 +746,14 @@ extern "C" {
 						}
 
 						if (cb->resampler) {
-							speex_resampler_process_interleaved_int(cb->resampler, (const spx_int16_t *) frame.data, (spx_uint32_t *) &in_len, &out[0], &out_len);						
-							streamer->write( &out[0], sizeof(spx_int16_t) * out_len);
+							speex_resampler_process_interleaved_int(cb->resampler, (const spx_int16_t *) frame.data, (spx_uint32_t *) &in_len, &out[0], &out_len);
+							/* out_len is per-channel samples; bytes = samples * 2 * channels */
+							streamer->write( &out[0], sizeof(spx_int16_t) * out_len * cb->channels);
 						}
 						else {
-							streamer->write( frame.data, sizeof(spx_int16_t) * frame.samples);
+							/* frame.samples is per-channel (media_bug_read divides by
+							   channel count); frame.datalen is the actual byte count */
+							streamer->write( frame.data, frame.datalen);
 						}
 					}
 				}

--- a/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
+++ b/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
@@ -444,18 +444,24 @@ static void *SWITCH_THREAD_FUNC aws_transcribe_thread(switch_thread_t *thread, v
 	struct cap_cb *cb = (struct cap_cb *) obj;
 	bool ok = true;
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "transcribe_thread: starting cb %p\n", (void *) cb);
-	/* new throws std::bad_alloc on failure (never returns null), so no null-check is needed here */
-	GStreamer* pStreamer = new GStreamer(cb->sessionId, cb->bugname, cb->channels, cb->lang, cb->interim, cb->samples_per_second, cb->region, cb->awsAccessKeyId, cb->awsSecretAccessKey,
-		cb->responseHandler);
-  if (!cb->vad) pStreamer->connect();
-	cb->streamer.store(pStreamer);
-	/* a stop/hangup may have arrived while the constructor was running: it
-	   found cb->streamer NULL, had nothing to finish(), and is (or will be)
-	   blocked in switch_thread_join. It sets stop_requested BEFORE loading
-	   cb->streamer and we re-check AFTER publishing it, so between the two
-	   orderings the request can never fall through the crack. */
-	if (cb->stop_requested.load()) pStreamer->finish();
-	pStreamer->processData(); //blocks until done
+	GStreamer* pStreamer = nullptr;
+	try {
+		pStreamer = new GStreamer(cb->sessionId, cb->bugname, cb->channels, cb->lang, cb->interim, cb->samples_per_second, cb->region, cb->awsAccessKeyId, cb->awsSecretAccessKey,
+			cb->responseHandler);
+		if (!cb->vad) pStreamer->connect();
+		cb->streamer.store(pStreamer);
+		/* a stop/hangup may have arrived while the constructor was running: it
+		   found cb->streamer NULL, had nothing to finish(), and is (or will be)
+		   blocked in switch_thread_join. It sets stop_requested BEFORE loading
+		   cb->streamer and we re-check AFTER publishing it, so between the two
+		   orderings the request can never fall through the crack. */
+		if (cb->stop_requested.load()) pStreamer->finish();
+		pStreamer->processData(); //blocks until done
+	} catch (const std::exception& e) {
+		/* an exception escaping a SWITCH_THREAD_FUNC is std::terminate -- the
+		   whole of FreeSWITCH, not just this session */
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "transcribe_thread: cb %p exception: %s\n", (void *) cb, e.what());
+	}
 
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "transcribe_thread: stopping cb %p\n", (void *) cb);
 	delete pStreamer;
@@ -638,7 +644,13 @@ extern "C" {
 		// create a thread to service the http/2 connection to aws
 		switch_threadattr_create(&thd_attr, pool);
 		switch_threadattr_stacksize_set(thd_attr, SWITCH_THREAD_STACKSIZE);
-		switch_thread_create(&cb->thread, thd_attr, aws_transcribe_thread, cb, pool);
+		if (switch_thread_create(&cb->thread, thd_attr, aws_transcribe_thread, cb, pool) != SWITCH_STATUS_SUCCESS) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error creating transcribe thread\n");
+			cb->thread = NULL;
+			killcb(cb);  /* frees the already-created resampler/vad; streamer is NULL */
+			status = SWITCH_STATUS_FALSE;
+			goto done;
+		}
 
 		*ppUserData = cb;
 	

--- a/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
+++ b/modules/mod_aws_transcribe/aws_transcribe_glue.cpp
@@ -4,6 +4,7 @@
 #include <switch_json.h>
 
 #include <string.h>
+#include <atomic>
 #include <mutex>
 #include <thread>
 #include <condition_variable>
@@ -23,7 +24,7 @@
 #include "mod_aws_transcribe.h"
 #include "simple_buffer.h"
 
-#define BUFFER_SECS (3)
+/* one audio chunk = 320 bytes = 160 samples (20ms) of 16-bit mono PCM at 8kHz */
 #define CHUNKSIZE (320)
 
 using namespace Aws;
@@ -36,6 +37,20 @@ using namespace Aws::TranscribeStreamingService::Model;
 const char ALLOC_TAG[] = "drachtio";
 
 static bool hasDefaultCredentials = false;
+
+/* RAII wrapper around switch_core_session_locate/switch_core_session_rwunlock so the
+   read-lock is always released on every exit path (early return, exception, scope end). */
+class SessionLock {
+public:
+	explicit SessionLock(const char* sessionId) : m_session(switch_core_session_locate(sessionId)) {}
+	~SessionLock() { if (m_session) switch_core_session_rwunlock(m_session); }
+	SessionLock(const SessionLock&) = delete;
+	SessionLock& operator=(const SessionLock&) = delete;
+	switch_core_session_t* get() const { return m_session; }
+	explicit operator bool() const { return m_session != nullptr; }
+private:
+	switch_core_session_t* m_session;
+};
 
 class GStreamer {
 public:
@@ -51,8 +66,9 @@ public:
 		const char* awsSecretAccessKey,
 		responseHandler_t responseHandler
   ) : m_sessionId(sessionId), m_bugname(bugname), m_finished(false), m_interim(interim), m_finishing(false), m_connected(false), m_connecting(false),
-	 		m_packets(0), m_responseHandler(responseHandler), m_pStream(nullptr), 
-			m_audioBuffer(320 * (samples_per_second == 8000 ? 1 : 2), 15) {
+	 		m_packets(0), m_responseHandler(responseHandler), m_pStream(nullptr),
+			/* prebuffer up to 15 chunks (CHUNKSIZE bytes for 8kHz, 2x for resampled 16kHz) until the stream is connected */
+			m_audioBuffer(CHUNKSIZE * (samples_per_second == 8000 ? 1 : 2), 15) {
 		Aws::String key(awsAccessKeyId);
 		Aws::String secret(awsSecretAccessKey);
 		Aws::Client::ClientConfiguration config;
@@ -73,14 +89,11 @@ public:
 	
     m_handler.SetTranscriptEventCallback([this](const TranscriptEvent& ev)
     {
-			switch_core_session_t* psession = switch_core_session_locate(m_sessionId.c_str());
+			SessionLock psession(m_sessionId.c_str());
 			if (psession) {
-				switch_channel_t* channel = switch_core_session_get_channel(psession);
 				std::lock_guard<std::mutex> lk(m_mutex);
 				m_transcript = ev;
 				m_cond.notify_one();
-
-				switch_core_session_rwunlock(psession);
 			}
     });
 
@@ -92,26 +105,25 @@ public:
 		if (channels > 1) m_request.SetNumberOfChannels(channels);
 
 		const char* var;
-		switch_core_session_t* session = switch_core_session_locate(sessionId);
+		SessionLock session(sessionId);
 		if (session) {
-			switch_channel_t *channel = switch_core_session_get_channel(session);
+			switch_channel_t *channel = switch_core_session_get_channel(session.get());
 
-			if (var = switch_channel_get_variable(channel, "AWS_SHOW_SPEAKER_LABEL")) {
+			if (switch_channel_get_variable(channel, "AWS_SHOW_SPEAKER_LABEL")) {
 				m_request.SetShowSpeakerLabel(true);
 			}
-			if (var = switch_channel_get_variable(channel, "AWS_ENABLE_CHANNEL_IDENTIFICATION")) {
+			if (switch_channel_get_variable(channel, "AWS_ENABLE_CHANNEL_IDENTIFICATION")) {
 				m_request.SetEnableChannelIdentification(true);
 			}
-			if (var = switch_channel_get_variable(channel, "AWS_VOCABULARY_NAME")) {
+			if ((var = switch_channel_get_variable(channel, "AWS_VOCABULARY_NAME"))) {
 				m_request.SetVocabularyName(var);
 			}
-			if (var = switch_channel_get_variable(channel, "AWS_VOCABULARY_FILTER_NAME")) {
+			if ((var = switch_channel_get_variable(channel, "AWS_VOCABULARY_FILTER_NAME"))) {
 				m_request.SetVocabularyFilterName(var);
 			}
-			if (var = switch_channel_get_variable(channel, "AWS_VOCABULARY_FILTER_METHOD")) {
+			if ((var = switch_channel_get_variable(channel, "AWS_VOCABULARY_FILTER_METHOD"))) {
 				m_request.SetVocabularyFilterMethod(VocabularyFilterMethodMapper::GetVocabularyFilterMethodForName(var));
 			}
-			switch_core_session_rwunlock(session);
 		}
 	}
 
@@ -123,17 +135,15 @@ public:
 
     auto OnStreamReady = [this](Model::AudioStream& stream)
     {
-			switch_core_session_t* psession = switch_core_session_locate(m_sessionId.c_str());
+			SessionLock psession(m_sessionId.c_str());
 			if (psession) {
-				switch_channel_t* channel = switch_core_session_get_channel(psession);
-
 				m_pStream = &stream;
 				m_connected = true;
 
 
 				// send any buffered audio
 				int nFrames = m_audioBuffer.getNumItems();
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p got stream ready, %d buffered frames\n", this, nFrames);	
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p got stream ready, %d buffered frames\n", this, nFrames);
 				if (nFrames) {
 					char *p;
 					do {
@@ -143,8 +153,6 @@ public:
 						}
 					} while (p);
 				}
-	
-				switch_core_session_rwunlock(psession);
 			}
     };
     auto OnResponseCallback = [this](const TranscribeStreamingServiceClient* pClient, 
@@ -153,9 +161,9 @@ public:
 			const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context)
     {
  			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p stream got final response\n", this);
-			switch_core_session_t* psession = switch_core_session_locate(m_sessionId.c_str());
+			SessionLock psession(m_sessionId.c_str());
 			if (psession) {
-				if (!outcome.IsSuccess()) {				
+				if (!outcome.IsSuccess()) {
 					const TranscribeStreamingServiceError& err = outcome.GetError();
 					auto message = err.GetMessage();
 					auto exception = err.GetExceptionName();
@@ -163,7 +171,7 @@ public:
 					cJSON_AddStringToObject(json, "type", "error");
 					cJSON_AddStringToObject(json, "error", message.c_str());
 					char* jsonString = cJSON_PrintUnformatted(json);
-					m_responseHandler(psession, jsonString, m_bugname.c_str());
+					m_responseHandler(psession.get(), jsonString, m_bugname.c_str());
 					free(jsonString);
 					cJSON_Delete(json);
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p stream got error response %s : %s\n", this, message.c_str(), exception.c_str());
@@ -172,8 +180,6 @@ public:
 				std::lock_guard<std::mutex> lk(m_mutex);
 				m_finished = true;
 				m_cond.notify_one();
-
-				switch_core_session_rwunlock(psession);
 			} else {
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p session is closed/hungup. Need to unblock thread.\n", this);
 				std::lock_guard<std::mutex> lk(m_mutex);
@@ -238,36 +244,35 @@ public:
 			if (m_finished || !m_connected) return;
 
 			if (m_transcript.TranscriptHasBeenSet()) {
-				switch_core_session_t* psession = switch_core_session_locate(m_sessionId.c_str());
+				SessionLock psession(m_sessionId.c_str());
 				if (psession) {
 
 					//switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer::got a transcript to send out %p\n", this);
 					bool isFinal = false;
-					std::ostringstream s;
-					s << "[";
+					/* build the transcript JSON via cJSON so transcript text is correctly escaped;
+					   shape is unchanged: [ {"is_final": <bool>, "alternatives": [ {"transcript": "<text>"} ]} ] */
+					cJSON* root = cJSON_CreateArray();
 					for (auto&& r : m_transcript.GetTranscript().GetResults()) {
-						int count = 0;
-						std::ostringstream t1;
 						if (!isFinal && !r.GetIsPartial()) isFinal = true;
-						t1 << "{\"is_final\": " << (r.GetIsPartial() ? "false" : "true") << ", \"alternatives\": [";
+						cJSON* result = cJSON_CreateObject();
+						cJSON_AddBoolToObject(result, "is_final", r.GetIsPartial() ? false : true);
+						cJSON* alternatives = cJSON_AddArrayToObject(result, "alternatives");
 						for (auto&& alt : r.GetAlternatives()) {
-							std::ostringstream t2;
-							if (count++ == 0) t2 << "{\"transcript\": \"" << alt.GetTranscript() << "\"}";
-							else t2 << ", {\"transcript\": \"" << alt.GetTranscript() << "\"}";
-							t1 << t2.str();
+							cJSON* alternative = cJSON_CreateObject();
+							cJSON_AddStringToObject(alternative, "transcript", alt.GetTranscript().c_str());
+							cJSON_AddItemToArray(alternatives, alternative);
 						}
-						t1 << "]}";
-						s << t1.str();
+						cJSON_AddItemToArray(root, result);
 					}
-					s << "]";
-					if (0 != s.str().compare("[]") && (isFinal || m_interim)) {
-						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer::writing transcript %p: %s\n", this, s.str().c_str() );
-						m_responseHandler(psession, s.str().c_str(), m_bugname.c_str());
+					char* jsonString = cJSON_PrintUnformatted(root);
+					if (jsonString && 0 != strcmp(jsonString, "[]") && (isFinal || m_interim)) {
+						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer::writing transcript %p: %s\n", this, jsonString);
+						m_responseHandler(psession.get(), jsonString, m_bugname.c_str());
 					}
+					if (jsonString) free(jsonString);
+					cJSON_Delete(root);
 					TranscriptEvent empty;
-					m_transcript = empty; 
-
-					switch_core_session_rwunlock(psession);
+					m_transcript = empty;
 				}
 			}
 			if (m_finishing) {
@@ -306,11 +311,11 @@ private:
 	StartStreamTranscriptionHandler m_handler;
 	TranscriptEvent m_transcript;
 	responseHandler_t m_responseHandler;
-	bool m_finishing;
+	std::atomic<bool> m_finishing;
 	bool m_interim;
-	bool m_finished;
-	bool m_connected;
-	bool m_connecting;
+	std::atomic<bool> m_finished;
+	std::atomic<bool> m_connected;
+	std::atomic<bool> m_connecting;
 	uint32_t m_packets;
 	std::mutex m_mutex;
 	std::condition_variable m_cond;
@@ -322,12 +327,9 @@ static void *SWITCH_THREAD_FUNC aws_transcribe_thread(switch_thread_t *thread, v
 	struct cap_cb *cb = (struct cap_cb *) obj;
 	bool ok = true;
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "transcribe_thread: starting cb %p\n", (void *) cb);
-	GStreamer* pStreamer = new GStreamer(cb->sessionId, cb->bugname, cb->channels, cb->lang, cb->interim, cb->samples_per_second, cb->region, cb->awsAccessKeyId, cb->awsSecretAccessKey, 
+	/* new throws std::bad_alloc on failure (never returns null), so no null-check is needed here */
+	GStreamer* pStreamer = new GStreamer(cb->sessionId, cb->bugname, cb->channels, cb->lang, cb->interim, cb->samples_per_second, cb->region, cb->awsAccessKeyId, cb->awsSecretAccessKey,
 		cb->responseHandler);
-	if (!pStreamer) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "transcribe_thread: Error allocating streamer\n");
-		return nullptr;
-	}
   if (!cb->vad) pStreamer->connect();
 	cb->streamer = pStreamer;
 	pStreamer->processData(); //blocks until done
@@ -487,16 +489,16 @@ extern "C" {
 				int voice_ms = 250;
 				int debug = 0;
 
-				if (var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_MODE")) {
+				if ((var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_MODE"))) {
 					mode = atoi(var);
 				}
-				if (var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_SILENCE_MS")) {
+				if ((var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_SILENCE_MS"))) {
 					silence_ms = atoi(var);
 				}
-				if (var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_VOICE_MS")) {
+				if ((var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_VOICE_MS"))) {
 					voice_ms = atoi(var);
 				}
-				if (var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_DEBUG")) {
+				if ((var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_DEBUG"))) {
 					debug = atoi(var);
 				}
 				switch_vad_set_mode(cb->vad, mode);
@@ -574,9 +576,10 @@ extern "C" {
 		if (switch_mutex_trylock(cb->mutex) == SWITCH_STATUS_SUCCESS) {
 			GStreamer* streamer = (GStreamer *) cb->streamer;
 			if (streamer) {
+				/* resampler output buffer, declared once and reused across loop iterations */
+				spx_int16_t out[SWITCH_RECOMMENDED_BUFFER_SIZE];
 				while (switch_core_media_bug_read(bug, &frame, SWITCH_TRUE) == SWITCH_STATUS_SUCCESS && !switch_test_flag((&frame), SFF_CNG)) {
 					if (frame.datalen) {
-						spx_int16_t out[SWITCH_RECOMMENDED_BUFFER_SIZE];
 						spx_uint32_t out_len = SWITCH_RECOMMENDED_BUFFER_SIZE;
 						spx_uint32_t in_len = frame.samples;
 						size_t written;

--- a/modules/mod_aws_transcribe/aws_transcribe_glue.h
+++ b/modules/mod_aws_transcribe/aws_transcribe_glue.h
@@ -6,6 +6,10 @@ switch_status_t aws_transcribe_cleanup();
 switch_status_t aws_transcribe_session_init(switch_core_session_t *session, responseHandler_t responseHandler, 
 		uint32_t samples_per_second, uint32_t channels, char* lang, int interim, char *bugname, void **ppUserData);
 switch_status_t aws_transcribe_session_stop(switch_core_session_t *session, int channelIsClosing, char* bugname);
+/* tear down a cap_cb whose worker thread/GStreamer were created by
+   aws_transcribe_session_init but which was never attached to a media bug
+   (e.g. switch_core_media_bug_add failed). Stops+joins the thread and frees. */
+void aws_transcribe_session_cleanup(void *pUserData);
 switch_bool_t aws_transcribe_frame(switch_media_bug_t *bug, void* user_data);
 
 #endif

--- a/modules/mod_aws_transcribe/mod_aws_transcribe.c
+++ b/modules/mod_aws_transcribe/mod_aws_transcribe.c
@@ -71,7 +71,7 @@ static void responseHandler(switch_core_session_t* session, const char * json, c
     			return;
     		}
     }
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "json payload: %s.\n", json);
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "json payload: %s.\n", json);
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "aws");
 		switch_event_add_body(event, "%s", json);
@@ -225,9 +225,25 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_aws_transcribe_load)
 {
 	switch_api_interface_t *api_interface;
 
-	/* create/register custom event message type */
+	/* create/register custom event message types */
 	if (switch_event_reserve_subclass(TRANSCRIBE_EVENT_RESULTS) != SWITCH_STATUS_SUCCESS) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", TRANSCRIBE_EVENT_RESULTS);
+		return SWITCH_STATUS_TERM;
+	}
+	if (switch_event_reserve_subclass(TRANSCRIBE_EVENT_END_OF_TRANSCRIPT) != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", TRANSCRIBE_EVENT_END_OF_TRANSCRIPT);
+		return SWITCH_STATUS_TERM;
+	}
+	if (switch_event_reserve_subclass(TRANSCRIBE_EVENT_NO_AUDIO_DETECTED) != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", TRANSCRIBE_EVENT_NO_AUDIO_DETECTED);
+		return SWITCH_STATUS_TERM;
+	}
+	if (switch_event_reserve_subclass(TRANSCRIBE_EVENT_MAX_DURATION_EXCEEDED) != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", TRANSCRIBE_EVENT_MAX_DURATION_EXCEEDED);
+		return SWITCH_STATUS_TERM;
+	}
+	if (switch_event_reserve_subclass(TRANSCRIBE_EVENT_VAD_DETECTED) != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", TRANSCRIBE_EVENT_VAD_DETECTED);
 		return SWITCH_STATUS_TERM;
 	}
 
@@ -257,5 +273,9 @@ SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_aws_transcribe_shutdown)
 {
 	aws_transcribe_cleanup();
 	switch_event_free_subclass(TRANSCRIBE_EVENT_RESULTS);
+	switch_event_free_subclass(TRANSCRIBE_EVENT_END_OF_TRANSCRIPT);
+	switch_event_free_subclass(TRANSCRIBE_EVENT_NO_AUDIO_DETECTED);
+	switch_event_free_subclass(TRANSCRIBE_EVENT_MAX_DURATION_EXCEEDED);
+	switch_event_free_subclass(TRANSCRIBE_EVENT_VAD_DETECTED);
 	return SWITCH_STATUS_SUCCESS;
 }

--- a/modules/mod_aws_transcribe/mod_aws_transcribe.c
+++ b/modules/mod_aws_transcribe/mod_aws_transcribe.c
@@ -18,6 +18,7 @@ static void responseHandler(switch_core_session_t* session, const char * json, c
 	switch_event_t *event = NULL;
 	switch_channel_t *channel = switch_core_session_get_channel(session);
 
+	if (!json) return;
 	if (0 == strcmp("vad_detected", json)) {
 		if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_VAD_DETECTED) != SWITCH_STATUS_SUCCESS) {
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "responseHandler: failed to create subclass %s\n", TRANSCRIBE_EVENT_VAD_DETECTED);

--- a/modules/mod_aws_transcribe/mod_aws_transcribe.c
+++ b/modules/mod_aws_transcribe/mod_aws_transcribe.c
@@ -15,26 +15,38 @@ SWITCH_MODULE_DEFINITION(mod_aws_transcribe, mod_aws_transcribe_load, mod_aws_tr
 static switch_status_t do_stop(switch_core_session_t *session, char* bugname);
 
 static void responseHandler(switch_core_session_t* session, const char * json, const char* bugname) {
-	switch_event_t *event;
+	switch_event_t *event = NULL;
 	switch_channel_t *channel = switch_core_session_get_channel(session);
 
 	if (0 == strcmp("vad_detected", json)) {
-		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_VAD_DETECTED);
+		if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_VAD_DETECTED) != SWITCH_STATUS_SUCCESS) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "responseHandler: failed to create subclass %s\n", TRANSCRIBE_EVENT_VAD_DETECTED);
+			return;
+		}
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "aws");
 	}
 	else if (0 == strcmp("end_of_transcript", json)) {
-		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_END_OF_TRANSCRIPT);
+		if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_END_OF_TRANSCRIPT) != SWITCH_STATUS_SUCCESS) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "responseHandler: failed to create subclass %s\n", TRANSCRIBE_EVENT_END_OF_TRANSCRIPT);
+			return;
+		}
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "aws");
 	}
 	else if (0 == strcmp("max_duration_exceeded", json)) {
-		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_MAX_DURATION_EXCEEDED);
+		if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_MAX_DURATION_EXCEEDED) != SWITCH_STATUS_SUCCESS) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "responseHandler: failed to create subclass %s\n", TRANSCRIBE_EVENT_MAX_DURATION_EXCEEDED);
+			return;
+		}
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "aws");
 	}
 	else if (0 == strcmp("no_audio", json)) {
-		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_NO_AUDIO_DETECTED);
+		if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_NO_AUDIO_DETECTED) != SWITCH_STATUS_SUCCESS) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "responseHandler: failed to create subclass %s\n", TRANSCRIBE_EVENT_NO_AUDIO_DETECTED);
+			return;
+		}
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "aws");
 	}
@@ -45,18 +57,26 @@ static void responseHandler(switch_core_session_t* session, const char * json, c
       const char* type = cJSON_GetStringValue(cJSON_GetObjectItem(jMessage, "type"));
       if (type && 0 == strcmp(type, "error")) {
         error = 1;
-    		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_ERROR);
+    		if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_ERROR) != SWITCH_STATUS_SUCCESS) {
+    			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "responseHandler: failed to create subclass %s\n", TRANSCRIBE_EVENT_ERROR);
+    			cJSON_Delete(jMessage);
+    			return;
+    		}
       }
       cJSON_Delete(jMessage);
     }
     if (!error) {
-    		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_RESULTS);
+    		if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_RESULTS) != SWITCH_STATUS_SUCCESS) {
+    			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "responseHandler: failed to create subclass %s\n", TRANSCRIBE_EVENT_RESULTS);
+    			return;
+    		}
     }
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "json payload: %s.\n", json);
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "aws");
 		switch_event_add_body(event, "%s", json);
 	}
+	if (!event) return;
 	if (bugname) switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "media-bugname", bugname);
 	switch_event_fire(&event);
 }
@@ -157,7 +177,8 @@ SWITCH_STANDARD_API(aws_transcribe_function)
 		argc = switch_separate_string(mycmd, ' ', argv, (sizeof(argv) / sizeof(argv[0])));
 	}
 
-	if (zstr(cmd) || 
+	if (zstr(cmd) ||
+      argc < 2 || zstr(argv[1]) ||
       (!strcasecmp(argv[1], "stop") && argc < 2) ||
       (!strcasecmp(argv[1], "start") && argc < 3) ||
       zstr(argv[0])) {

--- a/modules/mod_aws_transcribe/mod_aws_transcribe.c
+++ b/modules/mod_aws_transcribe/mod_aws_transcribe.c
@@ -263,6 +263,13 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_aws_transcribe_load)
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", TRANSCRIBE_EVENT_VAD_DETECTED);
 		return SWITCH_STATUS_TERM;
 	}
+	/* NB: the subclass NAME (inherited jambonz_transcribe::error) is frozen --
+	   external consumers key on it; this only adds the missing reservation the
+	   other five subclasses already had */
+	if (switch_event_reserve_subclass(TRANSCRIBE_EVENT_ERROR) != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", TRANSCRIBE_EVENT_ERROR);
+		return SWITCH_STATUS_TERM;
+	}
 
 	/* connect my internal structure to the blank pointer passed to me */
 	*module_interface = switch_loadable_module_create_module_interface(pool, modname);
@@ -294,5 +301,6 @@ SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_aws_transcribe_shutdown)
 	switch_event_free_subclass(TRANSCRIBE_EVENT_NO_AUDIO_DETECTED);
 	switch_event_free_subclass(TRANSCRIBE_EVENT_MAX_DURATION_EXCEEDED);
 	switch_event_free_subclass(TRANSCRIBE_EVENT_VAD_DETECTED);
+	switch_event_free_subclass(TRANSCRIBE_EVENT_ERROR);
 	return SWITCH_STATUS_SUCCESS;
 }

--- a/modules/mod_aws_transcribe/mod_aws_transcribe.c
+++ b/modules/mod_aws_transcribe/mod_aws_transcribe.c
@@ -206,8 +206,19 @@ SWITCH_STANDARD_API(aws_transcribe_function)
           flags |= SMBF_WRITE_STREAM ;
           flags |= SMBF_STEREO;
 				}
-    		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "start transcribing %s %s %s\n", lang, interim ? "interim": "complete", bugname);
-				status = start_capture(lsession, flags, lang, interim, bugname);
+				if (strlen(bugname) >= MAX_BUG_LEN) {
+					/* the channel private is stored under the FULL name but
+					   cb->bugname is a truncated copy used by the hangup CLOSE path;
+					   a longer name would make that stop miss the private and leak
+					   the worker thread + streamer past session destroy */
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR,
+						"bugname too long (max %d chars): %s\n", MAX_BUG_LEN - 1, bugname);
+					status = SWITCH_STATUS_FALSE;
+				}
+				else {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "start transcribing %s %s %s\n", lang, interim ? "interim": "complete", bugname);
+					status = start_capture(lsession, flags, lang, interim, bugname);
+				}
 			}
 			switch_core_session_rwunlock(lsession);
 		}

--- a/modules/mod_aws_transcribe/mod_aws_transcribe.c
+++ b/modules/mod_aws_transcribe/mod_aws_transcribe.c
@@ -141,6 +141,11 @@ static switch_status_t start_capture(switch_core_session_t *session, switch_medi
 		return SWITCH_STATUS_FALSE;
 	}
 	if ((status = switch_core_media_bug_add(session, bugname, NULL, capture_callback, pUserData, 0, flags, &bug)) != SWITCH_STATUS_SUCCESS) {
+		/* The bug was never attached, so the channel-private was never set and
+		   do_stop/session_stop can't find the cb. session_init already created the
+		   worker thread + GStreamer, so tear them down here to avoid leaking. */
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error adding media bug for aws transcribe; cleaning up session.\n");
+		aws_transcribe_session_cleanup(pUserData);
 		return status;
 	}
   switch_channel_set_private(channel, bugname, bug);

--- a/modules/mod_aws_transcribe/mod_aws_transcribe.c
+++ b/modules/mod_aws_transcribe/mod_aws_transcribe.c
@@ -188,7 +188,8 @@ SWITCH_STANDARD_API(aws_transcribe_function)
       (!strcasecmp(argv[1], "stop") && argc < 2) ||
       (!strcasecmp(argv[1], "start") && argc < 3) ||
       zstr(argv[0])) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s %s.\n", cmd, argv[0], argv[1]);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s %s.\n",
+			cmd ? cmd : "", argv[0] ? argv[0] : "", argv[1] ? argv[1] : "");
 		stream->write_function(stream, "-USAGE: %s\n", TRANSCRIBE_API_SYNTAX);
 		goto done;
 	} else {

--- a/modules/mod_aws_transcribe/mod_aws_transcribe.h
+++ b/modules/mod_aws_transcribe/mod_aws_transcribe.h
@@ -55,6 +55,17 @@ struct cap_cb {
 
 	switch_vad_t * vad;
 	uint32_t samples_per_second;
+	/* Set by stop/cleanup BEFORE they load cb->streamer; re-checked by the
+	   worker right AFTER it publishes cb->streamer. Closes the window where a
+	   stop lands while the GStreamer constructor is still running: the stop
+	   found no streamer to finish() and then blocked forever (VAD path) in
+	   switch_thread_join on a worker nothing would ever wake. Same
+	   C/C++ ABI pattern as streamer above (the .c file never touches it). */
+#ifdef __cplusplus
+	std::atomic<int> stop_requested;
+#else
+	int stop_requested;
+#endif
 };
 
 #endif

--- a/modules/mod_aws_transcribe/mod_aws_transcribe.h
+++ b/modules/mod_aws_transcribe/mod_aws_transcribe.h
@@ -6,6 +6,10 @@
 
 #include <unistd.h>
 
+#ifdef __cplusplus
+#include <atomic>
+#endif
+
 #define MY_BUG_NAME "aws_transcribe"
 #define MAX_BUG_LEN (64)
 #define MAX_SESSION_ID (256)
@@ -30,7 +34,18 @@ struct cap_cb {
   char awsSecretAccessKey[128];
 	uint32_t channels;
   SpeexResamplerState *resampler;
+	/* Published by the worker thread (aws_transcribe_thread) when the GStreamer is
+	   created and cleared when it is destroyed; read by the media-bug frame thread
+	   (aws_transcribe_frame) and the API stop/cleanup thread. The worker writes it
+	   WITHOUT holding cb->mutex, so the mutex alone cannot order those accesses --
+	   the pointer must be atomic. Touched only from C++ (the .c file never reads or
+	   writes cb->streamer), so the atomic type is confined to the C++ translation
+	   unit and the C ABI sees a plain void*. */
+#ifdef __cplusplus
+	std::atomic<void*> streamer;
+#else
 	void* streamer;
+#endif
 	responseHandler_t responseHandler;
 	switch_thread_t* thread;
 	int interim;

--- a/modules/mod_aws_transcribe/simple_buffer.h
+++ b/modules/mod_aws_transcribe/simple_buffer.h
@@ -1,15 +1,16 @@
 /**
- * (very) simple and limited circular buffer, 
+ * (very) simple and limited circular buffer,
  * supporting only the use case of doing all of the adds
  * and then subsquently retrieves.
- * 
+ *
  */
 class SimpleBuffer {
   public:
     SimpleBuffer(uint32_t chunkSize, uint32_t numChunks) : numItems(0),
-    m_numChunks(numChunks), m_chunkSize(chunkSize) {
+    m_chunkSize(chunkSize), m_numChunks(numChunks) {
       m_pData = new char[chunkSize * numChunks];
       m_pNextWrite = m_pData;
+      m_pNextRead = m_pData;
     }
     ~SimpleBuffer() {
       delete [] m_pData;
@@ -21,23 +22,32 @@ class SimpleBuffer {
       for (int i = 0; i < numChunks; i++) {
         memcpy(m_pNextWrite, data, m_chunkSize);
         data = static_cast<char*>(data) + m_chunkSize;
-        if (numItems < m_numChunks) numItems++;
 
         uint32_t offset = (m_pNextWrite - m_pData) / m_chunkSize;
         if (offset >= m_numChunks - 1) m_pNextWrite = m_pData;
         else m_pNextWrite += m_chunkSize;
+
+        if (numItems < m_numChunks) {
+          numItems++;
+        }
+        else {
+          // buffer was full: the oldest chunk was just overwritten, so advance
+          // the read cursor to keep it pointing at the new oldest chunk.
+          uint32_t roffset = (m_pNextRead - m_pData) / m_chunkSize;
+          if (roffset >= m_numChunks - 1) m_pNextRead = m_pData;
+          else m_pNextRead += m_chunkSize;
+        }
       }
     }
 
     char* getNextChunk() {
-      if (numItems--) {
-        char *p = m_pNextWrite;
-        uint32_t offset = (m_pNextWrite - m_pData) / m_chunkSize;
-        if (offset >= m_numChunks - 1) m_pNextWrite = m_pData;
-        else m_pNextWrite += m_chunkSize;
-        return p;
-      }
-      return nullptr;
+      if (numItems == 0) return nullptr;
+      numItems--;
+      char *p = m_pNextRead;
+      uint32_t offset = (m_pNextRead - m_pData) / m_chunkSize;
+      if (offset >= m_numChunks - 1) m_pNextRead = m_pData;
+      else m_pNextRead += m_chunkSize;
+      return p;
     }
 
     uint32_t getNumItems() { return numItems;}
@@ -48,4 +58,5 @@ class SimpleBuffer {
     uint32_t m_chunkSize;
     uint32_t m_numChunks;
     char* m_pNextWrite;
+    char* m_pNextRead;
 };

--- a/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
+++ b/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
@@ -65,8 +65,8 @@ public:
 		const char* region, 
 		const char* subscriptionKey, 
 		responseHandler_t responseHandler
-  ) : m_sessionId(sessionId), m_bugname(bugname), m_finished(false), m_stopped(false), m_interim(interim), 
-	 m_connected(false), m_connecting(false), m_audioBuffer(CHUNKSIZE, 15),
+  ) : m_sessionId(sessionId), m_bugname(bugname), m_finished(false), m_stopped(false), m_interim(interim),
+	 m_connected(false), m_connecting(false), m_canceled(false), m_audioBuffer(CHUNKSIZE, 15),
 	m_responseHandler(responseHandler) {
 
 		/* RAII: nearly every SDK call below can throw (SPX_THROW_HR in
@@ -197,13 +197,23 @@ public:
       switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(psession), SWITCH_LOG_DEBUG, "added %d hints\n", argc);
 		}
 
-		auto onSessionStopped = [this](const SessionEventArgs& args) {
+		auto onSessionStopped = [this, responseHandler](const SessionEventArgs& args) {
 			if (m_finished) return;
 			SessionLock lock(m_sessionId.c_str());
 			m_stopped = true;
 			if (lock) {
 				auto sessionId = args.SessionId;
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer: got session stopped from microsoft\n");
+				/* m_finished is false, so this stop was NOT initiated by us: azure
+				   ended the session unilaterally (silence timeout, service stop).
+				   Previously only a DEBUG log -- the external consumer could not
+				   distinguish a dead recognizer from silence. Canceled already
+				   fires its own error event; skip the duplicate on that path. */
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "GStreamer: azure session stopped unexpectedly (not initiated by us)\n");
+				if (!m_canceled) {
+					responseHandler(lock.get(), TRANSCRIBE_EVENT_ERROR,
+						"{\"type\":\"error\",\"error\":\"azure speech session stopped unexpectedly\"}",
+						m_bugname.c_str(), m_finished);
+				}
 			}
 		};
 		auto onSpeechStartDetected = [this, responseHandler](const RecognitionEventArgs& args) {
@@ -259,6 +269,7 @@ public:
 
 		auto onCanceled = [this, responseHandler](const SpeechRecognitionCanceledEventArgs& args) {
       if (m_finished) return;
+			m_canceled = true;
 			SessionLock lock(m_sessionId.c_str());
 			switch_core_session_t* psession = lock.get();
 			if (psession) {
@@ -364,11 +375,13 @@ public:
       switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
         "GStreamer::write %p exception writing to push stream: %s\n", this, e.what());
       m_finished = true;
+      notifyWriteFailure(e.what());
       return false;
     } catch (...) {
       switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
         "GStreamer::write %p unknown exception writing to push stream\n", this);
       m_finished = true;
+      notifyWriteFailure("unknown exception writing to azure push stream");
       return false;
     }
 		return true;
@@ -412,6 +425,23 @@ public:
 		return m_stopped;
 	}
 
+	/* surface a push-stream write failure as an error event: streaming has
+	   stopped for good (m_finished is set) and without an event the external
+	   consumer cannot distinguish the dead stream from silence */
+	void notifyWriteFailure(const char* what) {
+		SessionLock lock(m_sessionId.c_str());
+		if (!lock) return;
+		cJSON* json = cJSON_CreateObject();
+		cJSON_AddStringToObject(json, "type", "error");
+		cJSON_AddStringToObject(json, "error", what);
+		char* jsonString = cJSON_PrintUnformatted(json);
+		if (jsonString) {
+			m_responseHandler(lock.get(), TRANSCRIBE_EVENT_ERROR, jsonString, m_bugname.c_str(), m_finished);
+			free(jsonString);
+		}
+		cJSON_Delete(json);
+	}
+
 	bool isConnecting() {
     return m_connecting;
   }
@@ -430,6 +460,7 @@ private:
 	std::atomic<bool> m_connected;
 	std::atomic<bool> m_connecting;
 	std::atomic<bool> m_stopped;
+	std::atomic<bool> m_canceled;
 	/* guards m_audioBuffer only. The media thread (write() -> add()) and the SDK
 	   SessionStarted callback thread (drain via getNumItems()/getNextChunk())
 	   both touch the non-thread-safe SimpleBuffer. This lock is never held across

--- a/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
+++ b/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
@@ -373,8 +373,19 @@ public:
 		m_recognizer->Canceled.DisconnectAll();
 		m_recognizer->SessionStarted.DisconnectAll();
 
-		m_recognizer->StopContinuousRecognitionAsync().get();
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "GStreamer::finish - recognition has completed (%p)\n", this);
+		try {
+			m_recognizer->StopContinuousRecognitionAsync().get();
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "GStreamer::finish - recognition has completed (%p)\n", this);
+		} catch (const std::exception& e) {
+			/* .get() rethrows any exception the async stop stored (the SDK throws
+			   SPX_THROW_HR liberally, e.g. stopping a start whose connection
+			   already failed). finish() runs on a DETACHED reaper thread -- an
+			   escaping exception is std::terminate for all of FreeSWITCH. The
+			   handlers are already disconnected above, so teardown may proceed. */
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "GStreamer::finish - StopContinuousRecognitionAsync failed (%p): %s\n", this, e.what());
+		} catch (...) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "GStreamer::finish - StopContinuousRecognitionAsync failed (%p): unknown exception\n", this);
+		}
 	}
 
 	bool isStopped() {

--- a/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
+++ b/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
@@ -69,7 +69,13 @@ public:
 	 m_connected(false), m_connecting(false), m_audioBuffer(CHUNKSIZE, 15),
 	m_responseHandler(responseHandler) {
 
-		switch_core_session_t* psession = switch_core_session_locate(sessionId);
+		/* RAII: nearly every SDK call below can throw (SPX_THROW_HR in
+		   FromEndpoint/FromSubscription/SetProxy/FromConfig, bad_alloc, ...) and
+		   the catch in azure_transcribe_session_init cannot release a read lock
+		   it never sees -- a manual locate/rwunlock pair leaked the lock on any
+		   throw, permanently blocking that session's destruction */
+		SessionLock sessionLock(sessionId);
+		switch_core_session_t* psession = sessionLock.get();
 		if (!psession) throw std::invalid_argument( "session id no longer active" );
 		switch_channel_t *channel = switch_core_session_get_channel(psession);
  
@@ -262,8 +268,7 @@ public:
 		if (interim) m_recognizer->Recognizing += onRecognitionEvent;
 		m_recognizer->Recognized += onRecognitionEvent;
 		m_recognizer->Canceled += onCanceled;
-
-		switch_core_session_rwunlock(psession);
+		/* sessionLock releases the read lock here, on every path */
 	}
 
 	~GStreamer() {

--- a/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
+++ b/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
@@ -559,7 +559,10 @@ extern "C" {
 
 		/* determine if we need to resample the audio to 16-bit 8khz */
 		if (sampleRate != 8000) {
-			cb->resampler = speex_resampler_init(1, sampleRate, 8000, SWITCH_RESAMPLE_QUALITY, &err);
+			/* channels, not 1: stereo capture (SMBF_STEREO) delivers interleaved
+			   2-channel frames and the frame path uses the interleaved API (the
+			   Azure stream format is likewise declared with the channel count) */
+			cb->resampler = speex_resampler_init(channels, sampleRate, 8000, SWITCH_RESAMPLE_QUALITY, &err);
 			if (0 != err) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s: Error initializing resampler: %s.\n", 
 							switch_channel_get_name(channel), speex_resampler_strerror(err));
@@ -675,19 +678,21 @@ extern "C" {
 						}
 
 						if (cb->resampler) {
-							/* out[] is an array of int16 samples, so size it in sample units, not bytes */
+							/* out[] is an array of int16 samples, so size it in sample units, not bytes.
+							   The interleaved API takes capacity/counts in samples PER CHANNEL. */
 							spx_int16_t out[SWITCH_RECOMMENDED_BUFFER_SIZE / 2];
-							spx_uint32_t out_len = SWITCH_RECOMMENDED_BUFFER_SIZE / 2;
+							spx_uint32_t out_len = (SWITCH_RECOMMENDED_BUFFER_SIZE / 2) / cb->channels;
 							spx_uint32_t in_len = frame.samples;
 							size_t written;
-						
+
 							speex_resampler_process_interleaved_int(
 								cb->resampler,
 								(const spx_int16_t *) frame.data,
-								(spx_uint32_t *) &in_len, 
+								(spx_uint32_t *) &in_len,
 								&out[0],
 								&out_len);
-							streamer->write( &out[0], sizeof(spx_int16_t) * out_len);
+							/* out_len is per-channel samples; bytes = samples * 2 * channels */
+							streamer->write( &out[0], sizeof(spx_int16_t) * out_len * cb->channels);
 						}
 						else {
 							streamer->write( frame.data, frame.datalen);

--- a/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
+++ b/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
@@ -388,22 +388,28 @@ extern "C" {
 		uint32_t sampleRate = read_codec->implementation->actual_samples_per_second;
 		const char* sessionId = switch_core_session_get_uuid(session);
 		struct cap_cb* cb = (struct cap_cb *) switch_core_session_alloc(session, sizeof(*cb));
-		memset(cb, sizeof(cb), 0);
+		memset(cb, 0, sizeof(*cb));
 		const char* subscriptionKey = switch_channel_get_variable(channel, "AZURE_SUBSCRIPTION_KEY");
 		const char* region = switch_channel_get_variable(channel, "AZURE_REGION");
 		cb->channels = channels;
 		strncpy(cb->sessionId, sessionId, MAX_SESSION_ID);
+		cb->sessionId[MAX_SESSION_ID-1] = '\0';
 		strncpy(cb->bugname, bugname, MAX_BUG_LEN);
+		cb->bugname[MAX_BUG_LEN-1] = '\0';
 
 		if (subscriptionKey && region) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Using channel vars for azure authentication\n");
 			strncpy(cb->subscriptionKey, subscriptionKey, MAX_SUBSCRIPTION_KEY_LEN);
+			cb->subscriptionKey[MAX_SUBSCRIPTION_KEY_LEN-1] = '\0';
 			strncpy(cb->region, region, MAX_REGION);
+			cb->region[MAX_REGION-1] = '\0';
 		}
 		else if (std::getenv("AZURE_SUBSCRIPTION_KEY") && std::getenv("AZURE_REGION")) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Using env vars for azure authentication\n");
 			strncpy(cb->subscriptionKey, std::getenv("AZURE_SUBSCRIPTION_KEY"), MAX_SUBSCRIPTION_KEY_LEN);
+			cb->subscriptionKey[MAX_SUBSCRIPTION_KEY_LEN-1] = '\0';
 			strncpy(cb->region, std::getenv("AZURE_REGION"), MAX_REGION);
+			cb->region[MAX_REGION-1] = '\0';
 		}
 		else {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "No channel vars or env vars for azure authentication..will use default profile if found\n");
@@ -419,6 +425,7 @@ extern "C" {
 
 		cb->interim = interim;
 		strncpy(cb->lang, lang, MAX_LANG);
+		cb->lang[MAX_LANG-1] = '\0';
 
 		/* determine if we need to resample the audio to 16-bit 8khz */
 		if (sampleRate != 8000) {
@@ -469,8 +476,9 @@ extern "C" {
 			cb->streamer = streamer;
 			if (!cb->vad) streamer->connect();
 		} catch (std::exception& e) {
-			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s: Error initializing gstreamer: %s.\n", 
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s: Error initializing gstreamer: %s.\n",
 				switch_channel_get_name(channel), e.what());
+			killcb(cb);
 			return SWITCH_STATUS_FALSE;
 		}
 

--- a/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
+++ b/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
@@ -297,15 +297,19 @@ public:
 
 		auto onSessionStarted = [this](const SessionEventArgs& args) {
 			if (m_finished) return;
-			m_connected = true;
 			SessionLock lock(m_sessionId.c_str());
 			if (lock) {
 				auto sessionId = args.SessionId;
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer got session started from microsoft\n");
 
-				// send any buffered audio. m_connected is already true above, so the
-				// write() calls below take the push-stream path and never re-enter the
-				// add()/m_audioBufferMutex path, hence holding the lock here is safe.
+				/* Drain the prebuffer and only THEN publish m_connected, all under
+				   m_audioBufferMutex; write()'s pre-connect path re-checks the flag
+				   under this same lock, so a media frame can neither reach the push
+				   stream ahead of older prebuffered audio (reorder) nor land in the
+				   prebuffer after this one-shot drain (stranded forever). Write
+				   directly to the push stream -- calling write() here would take
+				   the pre-connect path (flag still false) and self-deadlock on this
+				   non-recursive mutex. */
 				std::lock_guard<std::mutex> lk(m_audioBufferMutex);
 				int nFrames = m_audioBuffer.getNumItems();
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p got session started from azure, %d buffered frames\n", this, nFrames);
@@ -314,10 +318,18 @@ public:
 					do {
 						p = m_audioBuffer.getNextChunk();
 						if (p) {
-							write(p, CHUNKSIZE);
+							try {
+								m_pushStream->Write(reinterpret_cast<uint8_t*>(p), CHUNKSIZE);
+							} catch (const std::exception& e) {
+								switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+									"GStreamer %p exception draining prebuffer: %s\n", this, e.what());
+								m_finished = true;
+								break;
+							}
 						}
 					} while (p);
 				}
+				m_connected = true;
 			}
 		};
 		m_recognizer->SessionStarted += onSessionStarted;
@@ -331,11 +343,19 @@ public:
 			return false;
 		}
 		if (!m_connected) {
-      if (datalen % CHUNKSIZE == 0) {
-        std::lock_guard<std::mutex> lk(m_audioBufferMutex);
-        m_audioBuffer.add(data, datalen);
+      std::lock_guard<std::mutex> lk(m_audioBufferMutex);
+      /* re-check under the lock: onSessionStarted publishes m_connected only
+         AFTER draining the prebuffer while holding this same mutex, so a frame
+         is either buffered strictly before the drain (and drained in order) or
+         sent strictly after it -- never reordered around it or stranded in a
+         buffer nobody reads again */
+      if (!m_connected) {
+        if (datalen % CHUNKSIZE == 0) {
+          m_audioBuffer.add(data, datalen);
+        }
+        return true;
       }
-      return true;
+      /* connected while acquiring the lock: fall through to the push stream */
     }
 
     try {

--- a/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
+++ b/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
@@ -435,6 +435,13 @@ static void killcb(struct cap_cb* cb) {
 	if (cb) {
 		if (cb->streamer) {
 			GStreamer* p = (GStreamer *) cb->streamer;
+			/* disconnect all handlers and stop recognition BEFORE deleting: the
+			   handler lambdas capture raw `this`, and this path is reached with
+			   them still connected (init-catch path when connect() throws after
+			   StartContinuousRecognitionAsync was dispatched) -- a raw delete
+			   there let a late SDK callback fire into freed memory. finish() is
+			   idempotent and no longer throws. */
+			p->finish();
 			delete p;
 			cb->streamer = NULL;
 		}

--- a/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
+++ b/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
@@ -89,8 +89,16 @@ public:
 		auto sourceLanguageConfig = SourceLanguageConfig::FromLanguage(lang);
 		auto format = AudioStreamFormat::GetWaveFormatPCM(8000, 16, channels);
 		auto options = AudioProcessingOptions::Create(AUDIO_INPUT_PROCESSING_ENABLE_DEFAULT);
-		auto speechConfig = nullptr != endpoint ? 
-			(nullptr != subscriptionKey ?
+		/* SPXSTRING is std::string: constructing it from a NULL const char* is
+		   undefined behavior (strlen on nullptr inside libstdc++). Treat
+		   NULL/empty uniformly and fail a keyless, endpointless start with a
+		   catchable exception instead of crashing FreeSWITCH. */
+		bool hasKey = (nullptr != subscriptionKey && *subscriptionKey);
+		if (nullptr == endpoint && !hasKey) {
+			throw std::invalid_argument("no azure subscription key configured (AZURE_SUBSCRIPTION_KEY channel var or env var) and no AZURE_SERVICE_ENDPOINT");
+		}
+		auto speechConfig = nullptr != endpoint ?
+			(hasKey ?
 				SpeechConfig::FromEndpoint(endpoint, subscriptionKey) :
 				SpeechConfig::FromEndpoint(endpoint)) :
 			SpeechConfig::FromSubscription(subscriptionKey, region);
@@ -540,7 +548,11 @@ extern "C" {
 		try {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "%s: initializing gstreamer with %s\n", 
 					switch_channel_get_name(channel), bugname);
-			streamer = new GStreamer(sessionId, bugname, channels, lang, interim, sampleRate, cb->region, subscriptionKey, responseHandler);
+			/* pass the resolved copies: cb->subscriptionKey/cb->region are filled
+			   from the channel vars OR the env vars -- the raw channel-var
+			   pointers are NULL under env-var-only auth (the env copies were
+			   previously dead stores and env auth crashed in the constructor) */
+			streamer = new GStreamer(sessionId, bugname, channels, lang, interim, sampleRate, cb->region, cb->subscriptionKey, responseHandler);
 			cb->streamer = streamer;
 			if (!cb->vad) streamer->connect();
 		} catch (std::exception& e) {

--- a/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
+++ b/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
@@ -340,6 +340,18 @@ public:
 						}
 					} while (p);
 				}
+				if (!m_finished && !m_prebufStaging.empty()) {
+					/* flush the sub-chunk staging remainder, in order */
+					try {
+						m_pushStream->Write(m_prebufStaging.data(), (uint32_t) m_prebufStaging.size());
+					} catch (const std::exception& e) {
+						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+							"GStreamer %p exception flushing prebuffer remainder: %s\n", this, e.what());
+						m_finished = true;
+					}
+				}
+				m_prebufStaging.clear();
+				m_prebufStaging.shrink_to_fit();
 				m_connected = true;
 			}
 		};
@@ -361,8 +373,17 @@ public:
          sent strictly after it -- never reordered around it or stranded in a
          buffer nobody reads again */
       if (!m_connected) {
-        if (datalen % CHUNKSIZE == 0) {
-          m_audioBuffer.add(data, datalen);
+        /* SimpleBuffer stores fixed CHUNKSIZE slices and its add() rejects
+           other lengths -- non-multiple frames (e.g. 480-byte 30ms-ptime
+           G.711, resampler output) were dropped wholesale, losing ALL
+           pre-connect audio for such codecs. Stage bytes and feed whole
+           chunks; the remainder is flushed at drain time. */
+        const uint8_t* p = static_cast<const uint8_t*>(data);
+        m_prebufStaging.insert(m_prebufStaging.end(), p, p + datalen);
+        size_t usable = (m_prebufStaging.size() / CHUNKSIZE) * CHUNKSIZE;
+        if (usable) {
+          m_audioBuffer.add(m_prebufStaging.data(), (uint32_t) usable);
+          m_prebufStaging.erase(m_prebufStaging.begin(), m_prebufStaging.begin() + usable);
         }
         return true;
       }
@@ -469,6 +490,8 @@ private:
 	   so it cannot deadlock. */
 	std::mutex m_audioBufferMutex;
 	SimpleBuffer m_audioBuffer;
+	/* sub-chunk staging for the pre-connect path; guarded by m_audioBufferMutex */
+	std::vector<uint8_t> m_prebufStaging;
 };
 
 static void reaper(struct cap_cb *cb) {

--- a/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
+++ b/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
@@ -284,7 +284,10 @@ public:
 				auto sessionId = args.SessionId;
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer got session started from microsoft\n");
 
-				// send any buffered audio
+				// send any buffered audio. m_connected is already true above, so the
+				// write() calls below take the push-stream path and never re-enter the
+				// add()/m_audioBufferMutex path, hence holding the lock here is safe.
+				std::lock_guard<std::mutex> lk(m_audioBufferMutex);
 				int nFrames = m_audioBuffer.getNumItems();
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p got session started from azure, %d buffered frames\n", this, nFrames);
 				if (nFrames) {
@@ -310,6 +313,7 @@ public:
 		}
 		if (!m_connected) {
       if (datalen % CHUNKSIZE == 0) {
+        std::lock_guard<std::mutex> lk(m_audioBufferMutex);
         m_audioBuffer.add(data, datalen);
       }
       return true;
@@ -376,6 +380,13 @@ private:
 	std::atomic<bool> m_connected;
 	std::atomic<bool> m_connecting;
 	std::atomic<bool> m_stopped;
+	/* guards m_audioBuffer only. The media thread (write() -> add()) and the SDK
+	   SessionStarted callback thread (drain via getNumItems()/getNextChunk())
+	   both touch the non-thread-safe SimpleBuffer. This lock is never held across
+	   a thread join, the reaper, or cb->mutex, and write()'s drain path runs with
+	   m_connected==true (so it never re-enters the add()/buffer-locked path),
+	   so it cannot deadlock. */
+	std::mutex m_audioBufferMutex;
 	SimpleBuffer m_audioBuffer;
 };
 

--- a/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
+++ b/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
@@ -178,6 +178,7 @@ public:
 		}
 
 		auto onSessionStopped = [this](const SessionEventArgs& args) {
+			if (m_finished) return;
 			SessionLock lock(m_sessionId.c_str());
 			m_stopped = true;
 			if (lock) {
@@ -186,6 +187,7 @@ public:
 			}
 		};
 		auto onSpeechStartDetected = [this, responseHandler](const RecognitionEventArgs& args) {
+			if (m_finished) return;
 			switch_core_session_t* psession = switch_core_session_locate(m_sessionId.c_str());
 			if (psession) {
 				auto sessionId = args.SessionId;
@@ -195,6 +197,7 @@ public:
 			}
 		};
 		auto onSpeechEndDetected = [this, responseHandler](const RecognitionEventArgs& args) {
+			if (m_finished) return;
 			switch_core_session_t* psession = switch_core_session_locate(m_sessionId.c_str());
 			if (psession) {
 				auto sessionId = args.SessionId;
@@ -204,6 +207,7 @@ public:
 			}
 		};
 		auto onRecognitionEvent = [this, responseHandler](const SpeechRecognitionEventArgs& args) {
+			if (m_finished) return;
 			SessionLock lock(m_sessionId.c_str());
 			switch_core_session_t* psession = lock.get();
 			if (psession) {
@@ -273,6 +277,7 @@ public:
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer:connect %p connecting to azure speech..\n", this);
 
 		auto onSessionStarted = [this](const SessionEventArgs& args) {
+			if (m_finished) return;
 			m_connected = true;
 			SessionLock lock(m_sessionId.c_str());
 			if (lock) {
@@ -330,6 +335,21 @@ public:
 		if (m_finished) return;
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer::finish - calling  StopContinuousRecognitionAsync (%p)\n", this);
 		m_finished = true;
+
+		/* Disconnect every event handler we connected before stopping recognition so that no
+		   late SDK callback can fire on this object while/after it is being torn down. The
+		   handler lambdas capture the raw `this`, and on teardown the owning GStreamer is
+		   deleted right after finish() returns; a callback arriving in that window would
+		   dereference freed memory. DisconnectAll() is safe on a signal with zero callbacks
+		   (e.g. Recognizing when interim==false, or SessionStarted if connect() never ran). */
+		m_recognizer->SessionStopped.DisconnectAll();
+		m_recognizer->SpeechStartDetected.DisconnectAll();
+		m_recognizer->SpeechEndDetected.DisconnectAll();
+		m_recognizer->Recognizing.DisconnectAll();
+		m_recognizer->Recognized.DisconnectAll();
+		m_recognizer->Canceled.DisconnectAll();
+		m_recognizer->SessionStarted.DisconnectAll();
+
 		m_recognizer->StopContinuousRecognitionAsync().get();
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "GStreamer::finish - recognition has completed (%p)\n", this);
 	}

--- a/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
+++ b/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
@@ -120,7 +120,13 @@ public:
 
     if (nullptr != proxyIP && nullptr != proxyPort) {
       switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(psession), SWITCH_LOG_DEBUG, "setting proxy: %s:%s\n", proxyIP, proxyPort);
-      speechConfig->SetProxy(proxyIP, atoi(proxyPort), proxyUsername, proxyPassword);
+      /* username/password are raw getenv results and NULL for an
+         unauthenticated proxy; SetProxy takes SPXSTRING (std::string) and
+         std::string(nullptr) is UB. The SDK's own defaults for these
+         parameters are empty SPXSTRING()s (speechapi_cxx_speech_config.h:377),
+         so empty string IS the SDK's no-credentials value. */
+      speechConfig->SetProxy(proxyIP, atoi(proxyPort),
+        proxyUsername ? proxyUsername : "", proxyPassword ? proxyPassword : "");
     }
 
 		m_pushStream = AudioInputStream::CreatePushStream(format);

--- a/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
+++ b/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
@@ -474,6 +474,16 @@ extern "C" {
 		return SWITCH_STATUS_SUCCESS;
 	}
 
+	void azure_transcribe_session_cleanup(void *pUserData) {
+		struct cap_cb *cb = (struct cap_cb *) pUserData;
+		if (!cb) return;
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+			"azure_transcribe_session_cleanup: tearing down orphaned cb %p (media bug never attached)\n", (void *) cb);
+		/* killcb finish()es the streamer (handlers disconnected, recognition
+		   stopped) before deleting it, then frees resampler/vad */
+		killcb(cb);
+	}
+
 	// start transcribe on a channel
 	switch_status_t azure_transcribe_session_init(switch_core_session_t *session, responseHandler_t responseHandler, 
           uint32_t samples_per_second, uint32_t channels, char* lang, int interim, char* bugname, void **ppUserData

--- a/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
+++ b/modules/mod_azure_transcribe/azure_transcribe_glue.cpp
@@ -4,6 +4,7 @@
 #include <switch_json.h>
 
 #include <string.h>
+#include <atomic>
 #include <mutex>
 #include <thread>
 #include <condition_variable>
@@ -17,6 +18,7 @@
 #include "mod_azure_transcribe.h"
 #include "simple_buffer.h"
 
+/* bytes in one 20ms frame of 8kHz 16-bit mono PCM (160 samples * 2 bytes) */
 #define CHUNKSIZE (320)
 #define DEFAULT_SPEECH_TIMEOUT "180000"
 
@@ -25,8 +27,26 @@ using namespace Microsoft::CognitiveServices::Speech::Audio;
 
 const char ALLOC_TAG[] = "drachtio";
 
+/* RAII wrapper around switch_core_session_locate/rwunlock so the session
+   read-lock is always released, including on the exception paths in the
+   SDK event callbacks. */
+class SessionLock {
+public:
+	explicit SessionLock(const char* sessionId) : m_session(switch_core_session_locate(sessionId)) {}
+	~SessionLock() { if (m_session) switch_core_session_rwunlock(m_session); }
+	SessionLock(const SessionLock&) = delete;
+	SessionLock& operator=(const SessionLock&) = delete;
+	switch_core_session_t* get() const { return m_session; }
+	explicit operator bool() const { return m_session != nullptr; }
+private:
+	switch_core_session_t* m_session;
+};
+
 static bool hasDefaultCredentials = false;
-static bool sdkInitialized = false;
+/* process-global one-shot: the SDK log filename is applied by the first
+   recognizer constructed; std::call_once makes the flip race-free across
+   concurrently constructed sessions */
+static std::once_flag sdkInitFlag;
 static const char* sdkLog = std::getenv("AZURE_SDK_LOGFILE");
 static const char* proxyIP = std::getenv("JAMBONES_HTTP_PROXY_IP");
 static const char* proxyPort = std::getenv("JAMBONES_HTTP_PROXY_PORT");
@@ -46,7 +66,7 @@ public:
 		const char* subscriptionKey, 
 		responseHandler_t responseHandler
   ) : m_sessionId(sessionId), m_bugname(bugname), m_finished(false), m_stopped(false), m_interim(interim), 
-	 m_connected(false), m_connecting(false), m_audioBuffer(320 * (samples_per_second == 8000 ? 1 : 2), 15),
+	 m_connected(false), m_connecting(false), m_audioBuffer(CHUNKSIZE, 15),
 	m_responseHandler(responseHandler) {
 
 		switch_core_session_t* psession = switch_core_session_locate(sessionId);
@@ -75,9 +95,10 @@ public:
       switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(psession), SWITCH_LOG_DEBUG, "setting endpoint id: %s\n", endpointId);
 			speechConfig->SetEndpointId(endpointId);
 		}
-		if (!sdkInitialized && sdkLog) {
-			sdkInitialized = true;
-			speechConfig->SetProperty(PropertyId::Speech_LogFilename, sdkLog);
+		if (sdkLog) {
+			std::call_once(sdkInitFlag, [&speechConfig]() {
+				speechConfig->SetProperty(PropertyId::Speech_LogFilename, sdkLog);
+			});
 		}
 		if (switch_true(switch_channel_get_variable(channel, "AZURE_AUDIO_LOGGING"))) {
 			speechConfig->EnableAudioLogging();
@@ -93,7 +114,7 @@ public:
 
     // alternative language
 		const char* var;
-    if (var = switch_channel_get_variable(channel, "AZURE_SPEECH_ALTERNATIVE_LANGUAGE_CODES")) {
+    if ((var = switch_channel_get_variable(channel, "AZURE_SPEECH_ALTERNATIVE_LANGUAGE_CODES"))) {
 			std::vector<std::string> languages;
 			char *alt_langs[3] = { 0 };
       int argc = switch_separate_string((char *) var, ',', alt_langs, 3);
@@ -157,12 +178,11 @@ public:
 		}
 
 		auto onSessionStopped = [this](const SessionEventArgs& args) {
-			switch_core_session_t* psession = switch_core_session_locate(m_sessionId.c_str());
+			SessionLock lock(m_sessionId.c_str());
 			m_stopped = true;
-			if (psession) {
+			if (lock) {
 				auto sessionId = args.SessionId;
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer: got session stopped from microsoft\n");
-				switch_core_session_rwunlock(psession);
 			}
 		};
 		auto onSpeechStartDetected = [this, responseHandler](const RecognitionEventArgs& args) {
@@ -184,7 +204,8 @@ public:
 			}
 		};
 		auto onRecognitionEvent = [this, responseHandler](const SpeechRecognitionEventArgs& args) {
-			switch_core_session_t* psession = switch_core_session_locate(m_sessionId.c_str());
+			SessionLock lock(m_sessionId.c_str());
+			switch_core_session_t* psession = lock.get();
 			if (psession) {
 				auto result = args.Result;
 				auto reason = result->Reason;
@@ -209,13 +230,13 @@ public:
 
 					break;
 				}
-				switch_core_session_rwunlock(psession);
 			}
 		};
 
 		auto onCanceled = [this, responseHandler](const SpeechRecognitionCanceledEventArgs& args) {
       if (m_finished) return;
-			switch_core_session_t* psession = switch_core_session_locate(m_sessionId.c_str());
+			SessionLock lock(m_sessionId.c_str());
+			switch_core_session_t* psession = lock.get();
 			if (psession) {
         auto result = args.Result;
         auto details = args.ErrorDetails;
@@ -227,7 +248,6 @@ public:
         responseHandler(psession, TRANSCRIBE_EVENT_ERROR, jsonString, m_bugname.c_str(), m_finished);
         free(jsonString);
         cJSON_Delete(json);
-				switch_core_session_rwunlock(psession);
         switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer recognition canceled, error %d: %s\n", code, details.c_str());
       }
 		};
@@ -254,14 +274,14 @@ public:
 
 		auto onSessionStarted = [this](const SessionEventArgs& args) {
 			m_connected = true;
-			switch_core_session_t* psession = switch_core_session_locate(m_sessionId.c_str());
-			if (psession) {
+			SessionLock lock(m_sessionId.c_str());
+			if (lock) {
 				auto sessionId = args.SessionId;
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer got session started from microsoft\n");
 
 				// send any buffered audio
 				int nFrames = m_audioBuffer.getNumItems();
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p got session started from azure, %d buffered frames\n", this, nFrames);	
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p got session started from azure, %d buffered frames\n", this, nFrames);
 				if (nFrames) {
 					char *p;
 					do {
@@ -271,7 +291,6 @@ public:
 						}
 					} while (p);
 				}
-				switch_core_session_rwunlock(psession);
 			}
 		};
 		m_recognizer->SessionStarted += onSessionStarted;
@@ -291,7 +310,19 @@ public:
       return true;
     }
 
-    m_pushStream->Write(static_cast<uint8_t*>(data), datalen);
+    try {
+      m_pushStream->Write(static_cast<uint8_t*>(data), datalen);
+    } catch (const std::exception& e) {
+      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+        "GStreamer::write %p exception writing to push stream: %s\n", this, e.what());
+      m_finished = true;
+      return false;
+    } catch (...) {
+      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+        "GStreamer::write %p unknown exception writing to push stream\n", this);
+      m_finished = true;
+      return false;
+    }
 		return true;
 	}
 
@@ -320,10 +351,11 @@ private:
 
 	responseHandler_t m_responseHandler;
 	bool m_interim;
-	bool m_finished;
-	bool m_connected;
-	bool m_connecting;
-	bool m_stopped;
+	/* written from SDK callback threads, read from the media thread */
+	std::atomic<bool> m_finished;
+	std::atomic<bool> m_connected;
+	std::atomic<bool> m_connecting;
+	std::atomic<bool> m_stopped;
 	SimpleBuffer m_audioBuffer;
 };
 
@@ -448,16 +480,16 @@ extern "C" {
 				int voice_ms = 250;
 				int debug = 0;
 
-				if (var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_MODE")) {
+				if ((var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_MODE"))) {
 					mode = atoi(var);
 				}
-				if (var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_SILENCE_MS")) {
+				if ((var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_SILENCE_MS"))) {
 					silence_ms = atoi(var);
 				}
-				if (var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_VOICE_MS")) {
+				if ((var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_VOICE_MS"))) {
 					voice_ms = atoi(var);
 				}
-				if (var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_DEBUG")) {
+				if ((var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_DEBUG"))) {
 					debug = atoi(var);
 				}
 				switch_vad_set_mode(cb->vad, mode);
@@ -541,8 +573,9 @@ extern "C" {
 						}
 
 						if (cb->resampler) {
-							spx_int16_t out[SWITCH_RECOMMENDED_BUFFER_SIZE];
-							spx_uint32_t out_len = SWITCH_RECOMMENDED_BUFFER_SIZE;
+							/* out[] is an array of int16 samples, so size it in sample units, not bytes */
+							spx_int16_t out[SWITCH_RECOMMENDED_BUFFER_SIZE / 2];
+							spx_uint32_t out_len = SWITCH_RECOMMENDED_BUFFER_SIZE / 2;
 							spx_uint32_t in_len = frame.samples;
 							size_t written;
 						

--- a/modules/mod_azure_transcribe/azure_transcribe_glue.h
+++ b/modules/mod_azure_transcribe/azure_transcribe_glue.h
@@ -6,6 +6,9 @@ switch_status_t azure_transcribe_cleanup();
 switch_status_t azure_transcribe_session_init(switch_core_session_t *session, responseHandler_t responseHandler, 
 		uint32_t samples_per_second, uint32_t channels, char* lang, int interim,  char* bugname, void **ppUserData);
 switch_status_t azure_transcribe_session_stop(switch_core_session_t *session, int channelIsClosing, char* bugname);
+/* teardown for a cap_cb whose media bug was never attached (bug-add failure):
+   stops the possibly-already-recognizing streamer and frees resampler/vad */
+void azure_transcribe_session_cleanup(void *pUserData);
 switch_bool_t azure_transcribe_frame(switch_media_bug_t *bug, void* user_data);
 
 #endif

--- a/modules/mod_azure_transcribe/mod_azure_transcribe.c
+++ b/modules/mod_azure_transcribe/mod_azure_transcribe.c
@@ -15,10 +15,13 @@ SWITCH_MODULE_DEFINITION(mod_azure_transcribe, mod_azure_transcribe_load, mod_az
 static switch_status_t do_stop(switch_core_session_t *session, char* bugname);
 
 static void responseHandler(switch_core_session_t* session, const char* eventName, const char * json, const char* bugname, int finished) {
-	switch_event_t *event;
+	switch_event_t *event = NULL;
 	switch_channel_t *channel = switch_core_session_get_channel(session);
-	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "responseHandler event %s, body %s.\n", eventName, json);
-	switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, eventName);
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "responseHandler event %s, body %s.\n", eventName, json);
+	if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, eventName) != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "responseHandler failed to create event subclass %s\n", eventName);
+		return;
+	}
 	switch_channel_event_set_data(channel, event);
 	switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "microsoft");
 	switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-session-finished", finished ? "true" : "false");
@@ -128,7 +131,8 @@ SWITCH_STANDARD_API(azure_transcribe_function)
 		argc = switch_separate_string(mycmd, ' ', argv, (sizeof(argv) / sizeof(argv[0])));
 	}
 
-	if (zstr(cmd) || 
+	if (zstr(cmd) ||
+      argc < 2 || zstr(argv[1]) ||
       (!strcasecmp(argv[1], "stop") && argc < 2) ||
       (!strcasecmp(argv[1], "start") && argc < 3) ||
       zstr(argv[0])) {

--- a/modules/mod_azure_transcribe/mod_azure_transcribe.c
+++ b/modules/mod_azure_transcribe/mod_azure_transcribe.c
@@ -133,7 +133,6 @@ SWITCH_STANDARD_API(azure_transcribe_function)
 
 	if (zstr(cmd) ||
       argc < 2 || zstr(argv[1]) ||
-      (!strcasecmp(argv[1], "stop") && argc < 2) ||
       (!strcasecmp(argv[1], "start") && argc < 3) ||
       zstr(argv[0])) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s %s.\n", cmd, argv[0], argv[1]);
@@ -196,6 +195,10 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_azure_transcribe_load)
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", TRANSCRIBE_EVENT_NO_SPEECH_DETECTED);
 		return SWITCH_STATUS_TERM;
 	}
+	if (switch_event_reserve_subclass(TRANSCRIBE_EVENT_VAD_DETECTED) != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", TRANSCRIBE_EVENT_VAD_DETECTED);
+		return SWITCH_STATUS_TERM;
+	}
 
 	/* connect my internal structure to the blank pointer passed to me */
 	*module_interface = switch_loadable_module_create_module_interface(pool, modname);
@@ -226,5 +229,6 @@ SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_azure_transcribe_shutdown)
 	switch_event_free_subclass(TRANSCRIBE_EVENT_START_OF_UTTERANCE);
 	switch_event_free_subclass(TRANSCRIBE_EVENT_END_OF_UTTERANCE);
 	switch_event_free_subclass(TRANSCRIBE_EVENT_NO_SPEECH_DETECTED);
+	switch_event_free_subclass(TRANSCRIBE_EVENT_VAD_DETECTED);
 	return SWITCH_STATUS_SUCCESS;
 }

--- a/modules/mod_azure_transcribe/mod_azure_transcribe.c
+++ b/modules/mod_azure_transcribe/mod_azure_transcribe.c
@@ -139,7 +139,8 @@ SWITCH_STANDARD_API(azure_transcribe_function)
       argc < 2 || zstr(argv[1]) ||
       (!strcasecmp(argv[1], "start") && argc < 3) ||
       zstr(argv[0])) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s %s.\n", cmd, argv[0], argv[1]);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s %s.\n",
+			cmd ? cmd : "", argv[0] ? argv[0] : "", argv[1] ? argv[1] : "");
 		stream->write_function(stream, "-USAGE: %s\n", TRANSCRIBE_API_SYNTAX);
 		goto done;
 	} else {
@@ -158,8 +159,19 @@ SWITCH_STANDARD_API(azure_transcribe_function)
           flags |= SMBF_WRITE_STREAM ;
           flags |= SMBF_STEREO;
 				}
-    		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "start transcribing %s %s %s\n", lang, interim ? "interim": "complete", bugname);
-				status = start_capture(lsession, flags, lang, interim, bugname);
+				if (strlen(bugname) >= MAX_BUG_LEN) {
+					/* the channel private is stored under the FULL name but
+					   cb->bugname is a truncated copy used by the hangup CLOSE path;
+					   a longer name would make that stop miss the private and never
+					   reap the recognizer */
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR,
+						"bugname too long (max %d chars): %s\n", MAX_BUG_LEN - 1, bugname);
+					status = SWITCH_STATUS_FALSE;
+				}
+				else {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "start transcribing %s %s %s\n", lang, interim ? "interim": "complete", bugname);
+					status = start_capture(lsession, flags, lang, interim, bugname);
+				}
 			}
 			switch_core_session_rwunlock(lsession);
 		}

--- a/modules/mod_azure_transcribe/mod_azure_transcribe.c
+++ b/modules/mod_azure_transcribe/mod_azure_transcribe.c
@@ -95,6 +95,10 @@ static switch_status_t start_capture(switch_core_session_t *session, switch_medi
 		return SWITCH_STATUS_FALSE;
 	}
 	if ((status = switch_core_media_bug_add(session, bugname, NULL, capture_callback, pUserData, 0, flags, &bug)) != SWITCH_STATUS_SUCCESS) {
+		/* session_init already created the recognizer and (non-VAD) started
+		   continuous recognition; without teardown it leaked and kept firing
+		   events for a start that reported failure */
+		azure_transcribe_session_cleanup(pUserData);
 		return status;
 	}
   switch_channel_set_private(channel, bugname, bug);

--- a/modules/mod_azure_transcribe/simple_buffer.h
+++ b/modules/mod_azure_transcribe/simple_buffer.h
@@ -1,15 +1,16 @@
 /**
- * (very) simple and limited circular buffer, 
+ * (very) simple and limited circular buffer,
  * supporting only the use case of doing all of the adds
  * and then subsquently retrieves.
- * 
+ *
  */
 class SimpleBuffer {
   public:
     SimpleBuffer(uint32_t chunkSize, uint32_t numChunks) : numItems(0),
-    m_numChunks(numChunks), m_chunkSize(chunkSize) {
+    m_chunkSize(chunkSize), m_numChunks(numChunks) {
       m_pData = new char[chunkSize * numChunks];
       m_pNextWrite = m_pData;
+      m_pNextRead = m_pData;
     }
     ~SimpleBuffer() {
       delete [] m_pData;
@@ -21,23 +22,32 @@ class SimpleBuffer {
       for (int i = 0; i < numChunks; i++) {
         memcpy(m_pNextWrite, data, m_chunkSize);
         data = static_cast<char*>(data) + m_chunkSize;
-        if (numItems < m_numChunks) numItems++;
 
         uint32_t offset = (m_pNextWrite - m_pData) / m_chunkSize;
         if (offset >= m_numChunks - 1) m_pNextWrite = m_pData;
         else m_pNextWrite += m_chunkSize;
+
+        if (numItems < m_numChunks) {
+          numItems++;
+        }
+        else {
+          // buffer was full: the oldest chunk was just overwritten, so advance
+          // the read cursor to keep it pointing at the new oldest chunk.
+          uint32_t roffset = (m_pNextRead - m_pData) / m_chunkSize;
+          if (roffset >= m_numChunks - 1) m_pNextRead = m_pData;
+          else m_pNextRead += m_chunkSize;
+        }
       }
     }
 
     char* getNextChunk() {
-      if (numItems--) {
-        char *p = m_pNextWrite;
-        uint32_t offset = (m_pNextWrite - m_pData) / m_chunkSize;
-        if (offset >= m_numChunks - 1) m_pNextWrite = m_pData;
-        else m_pNextWrite += m_chunkSize;
-        return p;
-      }
-      return nullptr;
+      if (numItems == 0) return nullptr;
+      numItems--;
+      char *p = m_pNextRead;
+      uint32_t offset = (m_pNextRead - m_pData) / m_chunkSize;
+      if (offset >= m_numChunks - 1) m_pNextRead = m_pData;
+      else m_pNextRead += m_chunkSize;
+      return p;
     }
 
     uint32_t getNumItems() { return numItems;}
@@ -48,4 +58,5 @@ class SimpleBuffer {
     uint32_t m_chunkSize;
     uint32_t m_numChunks;
     char* m_pNextWrite;
+    char* m_pNextRead;
 };

--- a/modules/mod_deepgram_transcribe/audio_pipe.cpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.cpp
@@ -294,9 +294,9 @@ static const lws_retry_bo_t retry = {
     0          // jitter_percent
 };
 
-struct lws_context *AudioPipe::contexts[] = {
-  nullptr, nullptr, nullptr, nullptr, nullptr,
-  nullptr, nullptr, nullptr, nullptr, nullptr
+std::atomic<struct lws_context*> AudioPipe::contexts[] = {
+  {nullptr}, {nullptr}, {nullptr}, {nullptr}, {nullptr},
+  {nullptr}, {nullptr}, {nullptr}, {nullptr}, {nullptr}
 };
 unsigned int AudioPipe::numContexts = 0;
 std::atomic<unsigned int> AudioPipe::nchild{0};
@@ -499,15 +499,16 @@ bool AudioPipe::lws_service_thread(unsigned int nServiceThread) {
 
   lwsl_notice("AudioPipe::lws_service_thread creating context in service thread %d.\n", nServiceThread);
 
-  contexts[nServiceThread] = lws_create_context(&info);
-  if (!contexts[nServiceThread]) {
-    lwsl_err("AudioPipe::lws_service_thread failed creating context in service thread %d..\n", nServiceThread); 
+  struct lws_context* myContext = lws_create_context(&info);
+  contexts[nServiceThread].store(myContext);
+  if (!myContext) {
+    lwsl_err("AudioPipe::lws_service_thread failed creating context in service thread %d..\n", nServiceThread);
     return false;
   }
 
   int n;
   do {
-    n = lws_service(contexts[nServiceThread], 0);
+    n = lws_service(myContext, 0);
   } while (n >= 0 && !stopRequested.load());
 
   lwsl_notice("AudioPipe::lws_service_thread ending in service thread %d\n", nServiceThread); 

--- a/modules/mod_deepgram_transcribe/audio_pipe.cpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.cpp
@@ -143,9 +143,31 @@ int AudioPipe::lws_callback(struct lws *wsi,
         if (lws_is_first_fragment(wsi)) {
           // allocate a buffer for the entire chunk of memory needed
           assert(nullptr == ap->m_recv_buf);
+          ap->m_recv_buf_discarding = false;
           ap->m_recv_buf_len = len + lws_remaining_packet_payload(wsi);
           ap->m_recv_buf = (uint8_t*) malloc(ap->m_recv_buf_len);
+          if (nullptr == ap->m_recv_buf) {
+            lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_RECEIVE recv buffer alloc failed, dropping message.\n");
+            ap->m_recv_buf_len = 0;
+            ap->m_recv_buf_discarding = !lws_is_final_fragment(wsi);
+            return 0;
+          }
           ap->m_recv_buf_ptr = ap->m_recv_buf;
+        }
+
+        if (ap->m_recv_buf_discarding) {
+          // Already abandoned this message (oversized, or its buffer alloc
+          // failed) on an earlier fragment. lws's first/final-fragment tracking
+          // is per-message, not aware of that abandonment, so without this
+          // check the code below would treat this continuation fragment as the
+          // start of a brand-new message -- and if it happens to be the
+          // message's final fragment, would deliver a truncated/garbled tail as
+          // a "complete" message instead of dropping it. Keep dropping
+          // fragments until the (abandoned) message actually ends.
+          if (lws_is_final_fragment(wsi)) {
+            ap->m_recv_buf_discarding = false;
+          }
+          return 0;
         }
 
         size_t write_offset = ap->m_recv_buf_ptr - ap->m_recv_buf;
@@ -157,6 +179,7 @@ int AudioPipe::lws_callback(struct lws *wsi,
             free(ap->m_recv_buf);
             ap->m_recv_buf = ap->m_recv_buf_ptr = nullptr;
             ap->m_recv_buf_len = 0;
+            ap->m_recv_buf_discarding = !lws_is_final_fragment(wsi);
             lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_RECEIVE max buffer exceeded, truncating message.\n");
           }
           else {
@@ -494,6 +517,7 @@ AudioPipe::AudioPipe(const char* uuid, const char* host, unsigned int port, cons
   m_uuid(uuid), m_host(host), m_port(port), m_path(path), m_finished(false),
   m_audio_buffer_min_freespace(minFreespace), m_audio_buffer_max_len(bufLen), m_gracefulShutdown(false),
   m_audio_buffer_write_offset(LWS_PRE), m_recv_buf(nullptr), m_recv_buf_ptr(nullptr),
+  m_recv_buf_discarding(false),
   m_state(LWS_CLIENT_IDLE), m_wsi(nullptr), m_vhd(nullptr), m_apiKey(apiKey), m_callback(callback),
   m_closeSignaled(false) {
 

--- a/modules/mod_deepgram_transcribe/audio_pipe.cpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.cpp
@@ -82,6 +82,15 @@ int AudioPipe::lws_callback(struct lws *wsi,
           *ppAp = ap;
           ap->m_vhd = vhd;
           ap->m_state = LWS_CLIENT_CONNECTED;
+          // A finish() call that arrived while still CONNECTING no-ops (nothing
+          // can be buffered for sending on a not-yet-connected pipe) and records
+          // the intent in m_gracefulShutdown instead. Complete it now rather
+          // than silently dropping it -- otherwise the reaper's waitForClose()
+          // blocks forever and this connection leaks for the rest of the
+          // process's life.
+          if (ap->m_gracefulShutdown) {
+            ap->finish();
+          }
           ap->m_callback(ap->m_uuid.c_str(), AudioPipe::CONNECT_SUCCESS, NULL,  ap->isFinished());
         }
         else {
@@ -547,8 +556,26 @@ void AudioPipe::close() {
 }
 
 void AudioPipe::finish() {
-  if (m_finished || m_state != LWS_CLIENT_CONNECTED) return;
-  m_finished = true;
+  if (m_state != LWS_CLIENT_CONNECTED) {
+    // Not connected yet (still IDLE/CONNECTING): CloseStream can't be buffered
+    // for sending until the handshake completes. Remember the request so
+    // LWS_CALLBACK_CLIENT_ESTABLISHED can complete it once connected --
+    // previously this was silently dropped, and if the connect subsequently
+    // succeeded, nothing else in the codebase ever called finish()/close()
+    // again for this pipe: the reaper's detached thread blocked forever in
+    // waitForClose() and the socket to deepgram stayed open indefinitely.
+    m_gracefulShutdown = true;
+    // The connect may have completed concurrently between the state check
+    // above and setting the flag; re-check rather than depending solely on
+    // ESTABLISHED's own read of m_gracefulShutdown, which could already have
+    // run (and seen it as still false) in that window. cppcheck's sequential
+    // data-flow analysis can't see that m_state is a cross-thread atomic
+    // another thread may mutate between the two reads -- this recheck is the
+    // point, not redundant.
+    // cppcheck-suppress identicalInnerCondition
+    if (m_state != LWS_CLIENT_CONNECTED) return;
+  }
+  if (m_finished.exchange(true)) return; // already finished by a concurrent caller
   bufferForSending("{\"type\": \"CloseStream\"}");
 }
 

--- a/modules/mod_deepgram_transcribe/audio_pipe.cpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.cpp
@@ -262,7 +262,10 @@ int AudioPipe::lws_callback(struct lws *wsi,
           if (ap->m_audio_buffer_write_offset > LWS_PRE) {
             size_t datalen = ap->m_audio_buffer_write_offset - LWS_PRE;
             int sent = lws_write(wsi, (unsigned char *) ap->m_audio_buffer + LWS_PRE, datalen, LWS_WRITE_BINARY);
-            if (sent < datalen) {
+            /* lws_write returns int (-1 on fatal error); comparing it against
+               the size_t datalen promoted -1 to SIZE_MAX and skipped the error
+               branch entirely, so write failures were silently discarded */
+            if (sent < (int) datalen) {
               lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_WRITEABLE %s attemped to send %lu only sent %d wsi %p..\n", 
                 ap->m_uuid.c_str(), datalen, sent, wsi); 
             }

--- a/modules/mod_deepgram_transcribe/audio_pipe.cpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.cpp
@@ -55,7 +55,7 @@ int AudioPipe::lws_callback(struct lws *wsi,
     case LWS_CALLBACK_EVENT_WAIT_CANCELLED:
       processPendingConnects(vhd);
       processPendingDisconnects(vhd);
-      processPendingWrites();
+      processPendingWrites(vhd);
       break;
     case LWS_CALLBACK_CLIENT_CONNECTION_ERROR:
       {
@@ -338,28 +338,45 @@ void AudioPipe::processPendingConnects(lws_per_vhost_data *vhd) {
 }
 
 void AudioPipe::processPendingDisconnects(lws_per_vhost_data *vhd) {
+  /* Only service pipes owned by THIS thread's context. lws wsi objects are not
+     thread-safe: with MOD_AUDIO_FORK_SERVICE_THREADS > 1 every context has its
+     own service thread, and the only lws call that may cross threads is
+     lws_cancel_service (which is how these lists get drained -- each add wakes
+     the owning pipe's context). Draining another context's entries here would
+     invoke lws_callback_on_writable on a wsi its own thread may be servicing
+     concurrently. Entries for other contexts are left in place for their own
+     thread's wakeup to process. */
   std::list<AudioPipe*> disconnects;
   {
     std::lock_guard<std::mutex> guard(mutex_disconnects);
-    for (auto it = pendingDisconnects.begin(); it != pendingDisconnects.end(); ++it) {
-      if ((*it)->m_state == LWS_CLIENT_DISCONNECTING) disconnects.push_back(*it);
+    for (auto it = pendingDisconnects.begin(); it != pendingDisconnects.end(); ) {
+      AudioPipe* ap = *it;
+      if (ap->m_vhd && ap->m_vhd->context == vhd->context) {
+        if (ap->m_state == LWS_CLIENT_DISCONNECTING) disconnects.push_back(ap);
+        it = pendingDisconnects.erase(it);
+      }
+      else ++it;
     }
-    pendingDisconnects.clear();
   }
   for (auto it = disconnects.begin(); it != disconnects.end(); ++it) {
     AudioPipe* ap = *it;
-    lws_callback_on_writable(ap->m_wsi); 
+    lws_callback_on_writable(ap->m_wsi);
   }
 }
 
-void AudioPipe::processPendingWrites() {
+void AudioPipe::processPendingWrites(lws_per_vhost_data *vhd) {
+  /* per-context filtering: see processPendingDisconnects */
   std::list<AudioPipe*> writes;
   {
     std::lock_guard<std::mutex> guard(mutex_writes);
-    for (auto it = pendingWrites.begin(); it != pendingWrites.end(); ++it) {
-       if ((*it)->m_state == LWS_CLIENT_CONNECTED) writes.push_back(*it);
-    }  
-    pendingWrites.clear();
+    for (auto it = pendingWrites.begin(); it != pendingWrites.end(); ) {
+      AudioPipe* ap = *it;
+      if (ap->m_vhd && ap->m_vhd->context == vhd->context) {
+        if (ap->m_state == LWS_CLIENT_CONNECTED) writes.push_back(ap);
+        it = pendingWrites.erase(it);
+      }
+      else ++it;
+    }
   }
   for (auto it = writes.begin(); it != writes.end(); ++it) {
     AudioPipe* ap = *it;

--- a/modules/mod_deepgram_transcribe/audio_pipe.cpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.cpp
@@ -517,11 +517,23 @@ bool AudioPipe::lws_service_thread(unsigned int nServiceThread) {
 
 void AudioPipe::initialize(unsigned int nThreads, int loglevel, log_emit_function logger) {
   assert(nThreads > 0 && nThreads <= 10);
-
-  numContexts = nThreads;
   lws_set_log_level(loglevel, logger);
 
-  lwsl_notice("AudioPipe::initialize starting %d threads\n", nThreads); 
+  if (nThreads > 1) {
+    /* Multi-context mode is capped to one service thread: the pending-CONNECT
+       list is shared across contexts, and the adopting service thread writes
+       ap->m_wsi / ap->m_vhd in connect_client() while another context's
+       ESTABLISHED/ERROR callback scans exactly those fields under
+       mutex_connects -- a ThreadSanitizer-verified data race (and
+       libwebsockets' own logging path also races across service threads).
+       Re-enable only after connect adoption is made per-context. */
+    lwsl_err("AudioPipe::initialize %d service threads requested; capped to 1 (multi-context connect adoption is not thread-safe)\n", nThreads);
+    nThreads = 1;
+  }
+
+  numContexts = nThreads;
+
+  lwsl_notice("AudioPipe::initialize starting %d threads\n", nThreads);
   stopRequested.store(false);
   for (unsigned int i = 0; i < numContexts; i++) {
     serviceThreads.emplace_back(&AudioPipe::lws_service_thread, i);

--- a/modules/mod_deepgram_transcribe/audio_pipe.cpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.cpp
@@ -541,7 +541,10 @@ AudioPipe::~AudioPipe() {
   // dereference this pipe after it is gone (see removeFromPending).
   removeFromPending(this);
   if (m_audio_buffer) delete [] m_audio_buffer;
-  if (m_recv_buf) delete [] m_recv_buf;
+  /* m_recv_buf is malloc/realloc'd by the receive path -- it must be free()d,
+     not delete[]d (mismatched allocator is UB and ASan-fatal). Non-null here
+     whenever the pipe dies with a fragmented message still in flight. */
+  if (m_recv_buf) free(m_recv_buf);
 }
 
 void AudioPipe::connect(void) {

--- a/modules/mod_deepgram_transcribe/audio_pipe.cpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.cpp
@@ -422,13 +422,26 @@ AudioPipe* AudioPipe::findPendingConnect(struct lws *wsi) {
 }
 
 void AudioPipe::addPendingConnect(AudioPipe* ap) {
+  /* a service thread whose lws_create_context failed leaves its slot NULL;
+     round-robin over the live ones instead of dereferencing a dead slot */
+  struct lws_context* ctx = nullptr;
+  for (unsigned int i = 0; i < numContexts && !ctx; i++) {
+    ctx = contexts[nchild++ % numContexts];
+  }
+  if (!ctx) {
+    lwsl_err("%s AudioPipe::addPendingConnect no live lws context, failing connect\n", ap->m_uuid.c_str());
+    ap->m_state = LWS_CLIENT_FAILED;
+    ap->m_callback(ap->m_uuid.c_str(), AudioPipe::CONNECT_FAIL, "no lws context available", ap->isFinished());
+    ap->setClosed();  // keep the reaper's waitForClose() from blocking forever
+    return;
+  }
   {
     std::lock_guard<std::mutex> guard(mutex_connects);
     pendingConnects.push_back(ap);
-    lwsl_debug("%s after adding connect there are %lu pending connects\n", 
+    lwsl_debug("%s after adding connect there are %lu pending connects\n",
       ap->m_uuid.c_str(), pendingConnects.size());
   }
-  lws_cancel_service(contexts[nchild++ % numContexts]);
+  lws_cancel_service(ctx);
 }
 void AudioPipe::addPendingDisconnect(AudioPipe* ap) {
   ap->m_state = LWS_CLIENT_DISCONNECTING;

--- a/modules/mod_deepgram_transcribe/audio_pipe.cpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.cpp
@@ -183,10 +183,23 @@ int AudioPipe::lws_callback(struct lws *wsi,
             lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_RECEIVE max buffer exceeded, truncating message.\n");
           }
           else {
-            ap->m_recv_buf = (uint8_t*) realloc(ap->m_recv_buf, newlen);
-            if (nullptr != ap->m_recv_buf) {
+            uint8_t* grown = (uint8_t*) realloc(ap->m_recv_buf, newlen);
+            if (nullptr != grown) {
+              ap->m_recv_buf = grown;
               ap->m_recv_buf_len = newlen;
               ap->m_recv_buf_ptr = ap->m_recv_buf + write_offset;
+            }
+            else {
+              // realloc failure leaves the original block valid: assigning the
+              // nullptr over m_recv_buf directly would leak it and leave
+              // m_recv_buf_ptr/m_recv_buf_len stale (poisoning the offset math
+              // of every later fragment). Drop the message and free the old
+              // buffer instead, then swallow fragments until it ends.
+              lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_RECEIVE recv buffer realloc failed, dropping message.\n");
+              free(ap->m_recv_buf);
+              ap->m_recv_buf = ap->m_recv_buf_ptr = nullptr;
+              ap->m_recv_buf_len = 0;
+              ap->m_recv_buf_discarding = !lws_is_final_fragment(wsi);
             }
           }
         }

--- a/modules/mod_deepgram_transcribe/audio_pipe.cpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.cpp
@@ -65,9 +65,12 @@ int AudioPipe::lws_callback(struct lws *wsi,
         if (ap) {
           ap->m_state = LWS_CLIENT_FAILED;
           ap->m_callback(ap->m_uuid.c_str(), AudioPipe::CONNECT_FAIL, (char *) in, ap->isFinished());
+          // terminal: no LWS_CALLBACK_CLIENT_CLOSED follows a failed connect, so
+          // fulfill the close promise here or the reaper would block forever.
+          ap->setClosed();
         }
         else {
-          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_CONNECTION_ERROR unable to find wsi %p..\n", wsi); 
+          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_CONNECTION_ERROR unable to find wsi %p..\n", wsi);
         }
       }      
       break;
@@ -275,7 +278,15 @@ void AudioPipe::processPendingConnects(lws_per_vhost_data *vhd) {
   }
   for (auto it = connects.begin(); it != connects.end(); ++it) {
     AudioPipe* ap = *it;
-    ap->connect_client(vhd);   
+    if (!ap->connect_client(vhd)) {
+      // synchronous connect failure: no wsi was created, so no CONNECTION_ERROR /
+      // CLOSED callback will follow. Notify and fulfill the close promise so the
+      // reaper can delete the pipe instead of blocking forever.
+      lwsl_err("%s connect_client failed synchronously\n", ap->m_uuid.c_str());
+      ap->m_state = LWS_CLIENT_FAILED;
+      ap->m_callback(ap->m_uuid.c_str(), AudioPipe::CONNECT_FAIL, (char *) "connect_client failed", ap->isFinished());
+      ap->setClosed();
+    }
   }
 }
 
@@ -470,8 +481,9 @@ AudioPipe::AudioPipe(const char* uuid, const char* host, unsigned int port, cons
   size_t bufLen, size_t minFreespace, const char* apiKey, notifyHandler_t callback) :
   m_uuid(uuid), m_host(host), m_port(port), m_path(path), m_finished(false),
   m_audio_buffer_min_freespace(minFreespace), m_audio_buffer_max_len(bufLen), m_gracefulShutdown(false),
-  m_audio_buffer_write_offset(LWS_PRE), m_recv_buf(nullptr), m_recv_buf_ptr(nullptr), 
-  m_state(LWS_CLIENT_IDLE), m_wsi(nullptr), m_vhd(nullptr), m_apiKey(apiKey), m_callback(callback) {
+  m_audio_buffer_write_offset(LWS_PRE), m_recv_buf(nullptr), m_recv_buf_ptr(nullptr),
+  m_state(LWS_CLIENT_IDLE), m_wsi(nullptr), m_vhd(nullptr), m_apiKey(apiKey), m_callback(callback),
+  m_closeSignaled(false) {
 
   m_audio_buffer = new uint8_t[m_audio_buffer_max_len];
 }
@@ -532,6 +544,14 @@ void AudioPipe::finish() {
   if (m_finished || m_state != LWS_CLIENT_CONNECTED) return;
   m_finished = true;
   bufferForSending("{\"type\": \"CloseStream\"}");
+}
+
+void AudioPipe::setClosed() {
+  // set-once: fulfill the promise exactly once no matter which terminal path runs
+  bool expected = false;
+  if (m_closeSignaled.compare_exchange_strong(expected, true)) {
+    m_promise.set_value();
+  }
 }
 
 void AudioPipe::waitForClose() {

--- a/modules/mod_deepgram_transcribe/audio_pipe.cpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.cpp
@@ -251,7 +251,7 @@ struct lws_context *AudioPipe::contexts[] = {
   nullptr, nullptr, nullptr, nullptr, nullptr
 };
 unsigned int AudioPipe::numContexts = 0;
-unsigned int AudioPipe::nchild = 0;
+std::atomic<unsigned int> AudioPipe::nchild{0};
 std::string AudioPipe::protocolName;
 std::mutex AudioPipe::mutex_connects;
 std::mutex AudioPipe::mutex_disconnects;

--- a/modules/mod_deepgram_transcribe/audio_pipe.cpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.cpp
@@ -260,9 +260,8 @@ std::list<AudioPipe*> AudioPipe::pendingConnects;
 std::list<AudioPipe*> AudioPipe::pendingDisconnects;
 std::list<AudioPipe*> AudioPipe::pendingWrites;
 AudioPipe::log_emit_function AudioPipe::logger;
-std::mutex AudioPipe::mapMutex;
-std::unordered_map<std::thread::id, bool> AudioPipe::stopFlags;
-std::queue<std::thread::id> AudioPipe::threadIds;
+std::atomic<bool> AudioPipe::stopRequested{false};
+std::vector<std::thread> AudioPipe::serviceThreads;
 
 
 void AudioPipe::processPendingConnects(lws_per_vhost_data *vhd) {
@@ -386,7 +385,6 @@ void AudioPipe::addPendingWrite(AudioPipe* ap) {
 
 bool AudioPipe::lws_service_thread(unsigned int nServiceThread) {
   struct lws_context_creation_info info;
-  std::thread::id this_id = std::this_thread::get_id();
 
   const struct lws_protocols protocols[] = {
     {
@@ -421,13 +419,7 @@ bool AudioPipe::lws_service_thread(unsigned int nServiceThread) {
   int n;
   do {
     n = lws_service(contexts[nServiceThread], 0);
-  } while (n >= 0 && !stopFlags[this_id]);
-
-  // Cleanup once work is done or stopped
-  {
-      std::lock_guard<std::mutex> lock(mapMutex);
-      stopFlags.erase(this_id);
-  }
+  } while (n >= 0 && !stopRequested.load());
 
   lwsl_notice("AudioPipe::lws_service_thread ending in service thread %d\n", nServiceThread); 
   return true;
@@ -440,23 +432,24 @@ void AudioPipe::initialize(unsigned int nThreads, int loglevel, log_emit_functio
   lws_set_log_level(loglevel, logger);
 
   lwsl_notice("AudioPipe::initialize starting %d threads\n", nThreads); 
+  stopRequested.store(false);
   for (unsigned int i = 0; i < numContexts; i++) {
-    std::lock_guard<std::mutex> lock(mapMutex);
-    std::thread t(&AudioPipe::lws_service_thread, i);
-    stopFlags[t.get_id()] = false;
-    threadIds.push(t.get_id());
-    t.detach();
+    serviceThreads.emplace_back(&AudioPipe::lws_service_thread, i);
   }
 }
 
 bool AudioPipe::deinitialize() {
-  lwsl_notice("AudioPipe::deinitialize\n"); 
-  std::lock_guard<std::mutex> lock(mapMutex);
-  if (!threadIds.empty()) {
-      std::thread::id id = threadIds.front();
-      threadIds.pop();
-      stopFlags[id] = true;
+  lwsl_notice("AudioPipe::deinitialize\n");
+  // Signal every service thread to stop, wake each lws context, and JOIN them
+  // before destroying contexts (no detached threads racing teardown).
+  stopRequested.store(true);
+  for (unsigned int i = 0; i < numContexts; i++) {
+    if (contexts[i]) lws_cancel_service(contexts[i]);
   }
+  for (auto& t : serviceThreads) {
+    if (t.joinable()) t.join();
+  }
+  serviceThreads.clear();
 /*
   do
   {
@@ -470,9 +463,8 @@ bool AudioPipe::deinitialize() {
   for (unsigned int i = 0; i < numContexts; i++)
   {
     lwsl_notice("AudioPipe::deinitialize destroying context %d of %d\n", i + 1, numContexts);
-    lws_context_destroy(contexts[i]);
+    if (contexts[i]) { lws_context_destroy(contexts[i]); contexts[i] = nullptr; }
   }
-  std::this_thread::sleep_for(std::chrono::seconds(2));
   return true;
 }
 

--- a/modules/mod_deepgram_transcribe/audio_pipe.cpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.cpp
@@ -51,6 +51,10 @@ int AudioPipe::lws_callback(struct lws *wsi,
           unsigned char **p = (unsigned char **)in, *end = (*p) + len;
           char b[256];
           memset(b, 0, sizeof(b));
+          if (apiKey.length() + 7 > sizeof(b)) {
+            lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_APPEND_HANDSHAKE_HEADER api key too long, max %lu\n", sizeof(b) - 7);
+            return -1;
+          }
           strcpy(b,"Token ");
           strcpy(b + 6, apiKey.c_str());
 
@@ -89,7 +93,7 @@ int AudioPipe::lws_callback(struct lws *wsi,
           ap->m_callback(ap->m_uuid.c_str(), AudioPipe::CONNECT_SUCCESS, NULL,  ap->isFinished());
         }
         else {
-          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_ESTABLISHED %s unable to find wsi %p..\n", ap->m_uuid.c_str(), wsi); 
+          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_ESTABLISHED unable to find wsi %p..\n", wsi);
         }
       }      
       break;
@@ -97,7 +101,7 @@ int AudioPipe::lws_callback(struct lws *wsi,
       {
         AudioPipe* ap = *ppAp;
         if (!ap) {
-          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_CLOSED %s unable to find wsi %p..\n", ap->m_uuid.c_str(), wsi); 
+          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_CLOSED unable to find wsi %p..\n", wsi);
           return 0;
         }
         if (ap->m_state == LWS_CLIENT_DISCONNECTING) {
@@ -126,7 +130,7 @@ int AudioPipe::lws_callback(struct lws *wsi,
       {
         AudioPipe* ap = *ppAp;
         if (!ap) {
-          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_RECEIVE %s unable to find wsi %p..\n", ap->m_uuid.c_str(), wsi); 
+          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_RECEIVE unable to find wsi %p..\n", wsi);
           return 0;
         }
 
@@ -185,7 +189,7 @@ int AudioPipe::lws_callback(struct lws *wsi,
       {
         AudioPipe* ap = *ppAp;
         if (!ap) {
-          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_WRITEABLE %s unable to find wsi %p..\n", ap->m_uuid.c_str(), wsi); 
+          lwsl_err("AudioPipe::lws_service_thread LWS_CALLBACK_CLIENT_WRITEABLE unable to find wsi %p..\n", wsi);
           return 0;
         }
 

--- a/modules/mod_deepgram_transcribe/audio_pipe.cpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.cpp
@@ -14,18 +14,7 @@ namespace {
   static int nTcpKeepaliveSecs = requestedTcpKeepaliveSecs ? ::atoi(requestedTcpKeepaliveSecs) : 55;
 }
 
-static int dch_lws_http_basic_auth_gen(const char *apiKey, char *buf, size_t len) {
-	size_t n = strlen(apiKey);
-
-	if (len < n + 7)
-		return 1;
-
-	strcpy(buf,"Token ");
-  strcpy(buf + 6, apiKey);
-	return 0;
-}
-
-int AudioPipe::lws_callback(struct lws *wsi, 
+int AudioPipe::lws_callback(struct lws *wsi,
   enum lws_callback_reasons reason,
   void *user, void *in, size_t len) {
 

--- a/modules/mod_deepgram_transcribe/audio_pipe.cpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.cpp
@@ -383,6 +383,17 @@ void AudioPipe::addPendingWrite(AudioPipe* ap) {
   lws_cancel_service(ap->m_vhd->context);
 }
 
+void AudioPipe::removeFromPending(AudioPipe* ap) {
+  // Each list is processed by the lws service thread under its own mutex
+  // (processPendingConnects/Disconnects/Writes read (*it)->m_state there), so
+  // taking the same mutex here serializes removal with those reads: the pipe is
+  // either still present and read while alive, or already gone — never read after
+  // free. Locks are taken one at a time (never nested), so no lock-order deadlock.
+  { std::lock_guard<std::mutex> guard(mutex_connects);    pendingConnects.remove(ap); }
+  { std::lock_guard<std::mutex> guard(mutex_disconnects); pendingDisconnects.remove(ap); }
+  { std::lock_guard<std::mutex> guard(mutex_writes);      pendingWrites.remove(ap); }
+}
+
 bool AudioPipe::lws_service_thread(unsigned int nServiceThread) {
   struct lws_context_creation_info info;
 
@@ -480,6 +491,9 @@ AudioPipe::AudioPipe(const char* uuid, const char* host, unsigned int port, cons
   m_audio_buffer = new uint8_t[m_audio_buffer_max_len];
 }
 AudioPipe::~AudioPipe() {
+  // Drop any lingering references before freeing so the lws service thread cannot
+  // dereference this pipe after it is gone (see removeFromPending).
+  removeFromPending(this);
   if (m_audio_buffer) delete [] m_audio_buffer;
   if (m_recv_buf) delete [] m_recv_buf;
 }

--- a/modules/mod_deepgram_transcribe/audio_pipe.hpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.hpp
@@ -9,6 +9,7 @@
 #include <queue>
 #include <unordered_map>
 #include <thread>
+#include <vector>
 
 #include <libwebsockets.h>
 
@@ -105,9 +106,11 @@ private:
   static std::list<AudioPipe*> pendingWrites;
   static log_emit_function logger;
 
-  static std::mutex mapMutex;
-  static std::unordered_map<std::thread::id, bool> stopFlags;
-  static std::queue<std::thread::id> threadIds;
+  /* shutdown coordination: deinitialize() sets stopRequested, wakes each lws
+     context, and JOINs the (non-detached) service threads before destroying the
+     contexts, so no service thread races teardown. */
+  static std::atomic<bool> stopRequested;
+  static std::vector<std::thread> serviceThreads;
 
   static AudioPipe* findAndRemovePendingConnect(struct lws *wsi);
   static AudioPipe* findPendingConnect(struct lws *wsi);

--- a/modules/mod_deepgram_transcribe/audio_pipe.hpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.hpp
@@ -123,7 +123,7 @@ private:
   static void removeFromPending(AudioPipe* ap);
   static void processPendingConnects(lws_per_vhost_data *vhd);
   static void processPendingDisconnects(lws_per_vhost_data *vhd);
-  static void processPendingWrites(void);
+  static void processPendingWrites(lws_per_vhost_data *vhd);
   
   bool connect_client(struct lws_per_vhost_data *vhd);
 

--- a/modules/mod_deepgram_transcribe/audio_pipe.hpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.hpp
@@ -146,6 +146,10 @@ private:
   uint8_t* m_recv_buf;
   uint8_t* m_recv_buf_ptr;
   size_t m_recv_buf_len;
+  /* true while dropping the remaining fragments of an inbound message that was
+     abandoned mid-delivery (oversized, or its buffer allocation failed); only
+     ever touched on the lws service thread */
+  bool m_recv_buf_discarding;
   struct lws_per_vhost_data* m_vhd;
   notifyHandler_t m_callback;
   log_emit_function m_logger;

--- a/modules/mod_deepgram_transcribe/audio_pipe.hpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.hpp
@@ -93,7 +93,7 @@ public:
 private:
 
   static int lws_callback(struct lws *wsi, enum lws_callback_reasons reason, void *user, void *in, size_t len); 
-  static unsigned int nchild;
+  static std::atomic<unsigned int> nchild;
   static struct lws_context *contexts[];
   static unsigned int numContexts;
   static std::string protocolName;

--- a/modules/mod_deepgram_transcribe/audio_pipe.hpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <list>
+#include <atomic>
 #include <mutex>
 #include <future>
 #include <queue>
@@ -115,7 +116,9 @@ private:
   
   bool connect_client(struct lws_per_vhost_data *vhd);
 
-  LwsState_t m_state;
+  /* connection-state flag shared between the lws service thread and the
+     media-bug/reaper threads; atomic so reads/writes don't race (seq_cst) */
+  std::atomic<LwsState_t> m_state;
   std::string m_uuid;
   std::string m_host;
   unsigned int m_port;
@@ -136,8 +139,9 @@ private:
   notifyHandler_t m_callback;
   log_emit_function m_logger;
   std::string m_apiKey;
-  bool m_gracefulShutdown;
-  bool m_finished;
+  /* cross-thread flags (written by reaper/finish, read by lws callbacks) */
+  std::atomic<bool> m_gracefulShutdown;
+  std::atomic<bool> m_finished;
   std::string m_bugname;
   std::promise<void> m_promise;
 };

--- a/modules/mod_deepgram_transcribe/audio_pipe.hpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.hpp
@@ -95,7 +95,10 @@ private:
 
   static int lws_callback(struct lws *wsi, enum lws_callback_reasons reason, void *user, void *in, size_t len); 
   static std::atomic<unsigned int> nchild;
-  static struct lws_context *contexts[];
+  /* written by each service thread at startup (lws_create_context) and read
+     by connecting threads (addPendingConnect/addPendingWrite wake targets);
+     atomic slots give those cross-thread accesses a happens-before edge */
+  static std::atomic<struct lws_context*> contexts[];
   static unsigned int numContexts;
   static std::string protocolName;
   static std::mutex mutex_connects;

--- a/modules/mod_deepgram_transcribe/audio_pipe.hpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.hpp
@@ -67,7 +67,7 @@ public:
     m_audio_buffer_write_offset += len;
   }
   void binaryWritePtrResetToZero(void) {
-    m_audio_buffer_write_offset = 0;
+    m_audio_buffer_write_offset = LWS_PRE;
   }
   void lockAudioBuffer(void) {
     m_audio_mutex.lock();

--- a/modules/mod_deepgram_transcribe/audio_pipe.hpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.hpp
@@ -117,6 +117,10 @@ private:
   static void addPendingConnect(AudioPipe* ap);
   static void addPendingDisconnect(AudioPipe* ap);
   static void addPendingWrite(AudioPipe* ap);
+  /* Remove ap from every pending list under the list mutexes. Called from the
+     destructor so a reaped pipe cannot be dereferenced by the lws service thread
+     (which reads (*it)->m_state under those same mutexes) after it is freed. */
+  static void removeFromPending(AudioPipe* ap);
   static void processPendingConnects(lws_per_vhost_data *vhd);
   static void processPendingDisconnects(lws_per_vhost_data *vhd);
   static void processPendingWrites(void);

--- a/modules/mod_deepgram_transcribe/audio_pipe.hpp
+++ b/modules/mod_deepgram_transcribe/audio_pipe.hpp
@@ -78,7 +78,11 @@ public:
   void close() ;
   void finish();
   void waitForClose();
-  void setClosed() { m_promise.set_value(); }
+
+  // Promise-based close signalling. The lws CLOSED / CONNECT_FAIL paths call
+  // setClosed() (set-once); the reaper blocks in waitForClose() before deleting
+  // the AudioPipe, so the object always outlives any lws-thread use of it.
+  void setClosed();
   bool isFinished() { return m_finished;}
 
   // no default constructor or copying
@@ -143,6 +147,9 @@ private:
   std::atomic<bool> m_gracefulShutdown;
   std::atomic<bool> m_finished;
   std::string m_bugname;
+  /* set-once guard so the close promise is fulfilled exactly once regardless of
+     which terminal path (graceful close, far-end drop, or connect failure) runs */
+  std::atomic<bool> m_closeSignaled;
   std::promise<void> m_promise;
 };
 

--- a/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
+++ b/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
@@ -24,6 +24,29 @@
 #define FRAME_SIZE_8000  320 /*which means each 20ms frame as 320 bytes at 8 khz (1 channel only)*/
 
 namespace {
+  /* RAII guard for switch_core_session_locate / switch_core_session_rwunlock.
+     Locates on construction; rwunlocks on destruction so every exit path releases
+     the read lock. Behavior is identical to the manual locate/unlock pattern. */
+  struct SessionLock {
+    switch_core_session_t* session;
+    explicit SessionLock(const char* uuid) : session(switch_core_session_locate(uuid)) {}
+    ~SessionLock() { if (session) switch_core_session_rwunlock(session); }
+    SessionLock(const SessionLock&) = delete;
+    SessionLock& operator=(const SessionLock&) = delete;
+  };
+
+  /* RAII unlock guard for switch_mutex_t. It does NOT acquire the lock: it adopts
+     an already-held mutex (e.g. one taken via switch_mutex_trylock) and unlocks it
+     on every exit path so a locked region cannot leak the mutex on an early return.
+     Trylock semantics at the call site are preserved exactly. */
+  struct MutexUnlockGuard {
+    switch_mutex_t* mutex;
+    explicit MutexUnlockGuard(switch_mutex_t* m) : mutex(m) {}
+    ~MutexUnlockGuard() { switch_mutex_unlock(mutex); }
+    MutexUnlockGuard(const MutexUnlockGuard&) = delete;
+    MutexUnlockGuard& operator=(const MutexUnlockGuard&) = delete;
+  };
+
   static bool hasDefaultCredentials = false;
   static const char* defaultApiKey = nullptr;
   static const char *requestedBufferSecs = std::getenv("MOD_AUDIO_FORK_BUFFER_SECS");
@@ -166,7 +189,7 @@ namespace {
       if (customModel) oss << "&model=" << customModel;
     }
 
-    if (var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_MODEL_VERSION")) {
+    if ((var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_MODEL_VERSION"))) {
      oss <<  "&version=";
      oss <<  var;
     }
@@ -178,7 +201,7 @@ namespace {
      oss <<  "&channels=2";
     }
 
-    if (var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_ENABLE_SMART_FORMAT")) {
+    if ((var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_ENABLE_SMART_FORMAT"))) {
      oss <<  "&smart_format=true";
      oss <<  "&no_delay=true";
      /**
@@ -186,19 +209,19 @@ namespace {
       * 
       */
     }
-    if (var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_ENABLE_AUTOMATIC_PUNCTUATION")) {
+    if ((var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_ENABLE_AUTOMATIC_PUNCTUATION"))) {
      oss <<  "&punctuate=true";
     }
     if (switch_true(switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_PROFANITY_FILTER"))) {
      oss <<  "&profanity_filter=true";
     }
-    if (var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_REDACT")) {
+    if ((var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_REDACT"))) {
      oss <<  "&redact=";
      oss <<  var;
     }
     if (switch_true(switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_DIARIZE"))) {
      oss <<  "&diarize=true";
-      if (var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_DIARIZE_VERSION")) {
+      if ((var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_DIARIZE_VERSION"))) {
        oss <<  "&diarize_version=";
        oss <<  var;
       }
@@ -206,7 +229,7 @@ namespace {
     if (switch_true(switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_NER"))) {
      oss <<  "&ner=true";
     }
-    if (var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_ALTERNATIVES")) {
+    if ((var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_ALTERNATIVES"))) {
      oss <<  "&alternatives=";
      oss <<  var;
     }
@@ -241,22 +264,22 @@ namespace {
        oss <<  encodeURIComponent(phrases[i]);
       }
 		}
-    if (var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_TAG")) {
+    if ((var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_TAG"))) {
      oss <<  "&tag=";
      oss <<  var;
     }
     if (interim) {
      oss <<  "&interim_results=true";
     }
-    if (var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_ENDPOINTING")) {
+    if ((var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_ENDPOINTING"))) {
       oss <<  "&endpointing=";
       oss <<  var;
     }
-    if (var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_UTTERANCE_END_MS")) {
+    if ((var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_UTTERANCE_END_MS"))) {
       oss <<  "&utterance_end_ms=";
       oss <<  var;
     }
-    if (var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_VAD_TURNOFF")) {
+    if ((var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_VAD_TURNOFF"))) {
       oss <<  "&vad_turnoff=";
       oss <<  var;
     }
@@ -267,7 +290,8 @@ namespace {
   }
 
   static void eventCallback(const char* sessionId, deepgram::AudioPipe::NotifyEvent_t event, const char* message, bool finished) {
-    switch_core_session_t* session = switch_core_session_locate(sessionId);
+    SessionLock sl(sessionId);
+    switch_core_session_t* session = sl.session;
     if (session) {
       switch_channel_t *channel = switch_core_session_get_channel(session);
       switch_media_bug_t *bug = (switch_media_bug_t*) switch_channel_get_private(channel, MY_BUG_NAME);
@@ -316,10 +340,9 @@ namespace {
           }
         }
       }
-      switch_core_session_rwunlock(session);
     }
   }
-  switch_status_t fork_data_init(private_t *tech_pvt, switch_core_session_t *session, 
+  switch_status_t fork_data_init(private_t *tech_pvt, switch_core_session_t *session,
     int sampling, int desiredSampling, int channels, char *lang, int interim, 
     char* bugname, responseHandler_t responseHandler) {
 
@@ -348,6 +371,8 @@ namespace {
     tech_pvt->id = ++idxCallCount;
     tech_pvt->buffer_overrun_notified = 0;
     
+    /* size the send buffer to hold nAudioBufferSecs of L16 audio:
+       (bytes per 20ms frame) * (frames per second) * channels * seconds, plus LWS_PRE headroom */
     size_t buflen = LWS_PRE + (FRAME_SIZE_8000 * desiredSampling / 8000 * channels * 1000 / RTP_PACKETIZATION_PERIOD * nAudioBufferSecs);
 
     const char* apiKey = switch_channel_get_variable(channel, "DEEPGRAM_API_KEY");
@@ -393,9 +418,8 @@ namespace {
       case LLL_WARN: llevel = SWITCH_LOG_WARNING; break;
       case LLL_NOTICE: llevel = SWITCH_LOG_NOTICE; break;
       case LLL_INFO: llevel = SWITCH_LOG_INFO; break;
-      break;
     }
-	  switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "%s\n", line);
+	  switch_log_printf(SWITCH_CHANNEL_LOG, llevel, "%s\n", line);
   }
 }
 
@@ -405,7 +429,9 @@ extern "C" {
     switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "mod_deepgram_transcribe: audio buffer (in secs):    %d secs\n", nAudioBufferSecs);
     switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "mod_deepgram_transcribe: lws service threads:       %d\n", nServiceThreads);
  
-    int logs = LLL_ERR | LLL_WARN | LLL_NOTICE || LLL_INFO | LLL_PARSER | LLL_HEADER | LLL_EXT | LLL_CLIENT  | LLL_LATENCY | LLL_DEBUG ;
+    /* deliberate mask: preserve today's effective verbosity (ERR|WARN|NOTICE).
+       Do not enable LLL_INFO/LLL_DEBUG: at scale they flood the logs. */
+    int logs = LLL_ERR | LLL_WARN | LLL_NOTICE;
     
     deepgram::AudioPipe::initialize(nServiceThreads, logs, lws_logger);
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "AudioPipe::initialize completed\n");
@@ -496,13 +522,13 @@ extern "C" {
     if (!tech_pvt) return SWITCH_TRUE;
     
     if (switch_mutex_trylock(tech_pvt->mutex) == SWITCH_STATUS_SUCCESS) {
+      /* lock already acquired via trylock above; guard unlocks it on every exit path */
+      MutexUnlockGuard mlk(tech_pvt->mutex);
       if (!tech_pvt->pAudioPipe) {
-        switch_mutex_unlock(tech_pvt->mutex);
         return SWITCH_TRUE;
       }
       deepgram::AudioPipe *pAudioPipe = static_cast<deepgram::AudioPipe *>(tech_pvt->pAudioPipe);
       if (pAudioPipe->getLwsState() != deepgram::AudioPipe::LWS_CLIENT_CONNECTED) {
-        switch_mutex_unlock(tech_pvt->mutex);
         return SWITCH_TRUE;
       }
 
@@ -575,7 +601,7 @@ extern "C" {
       }
 
       pAudioPipe->unlockAudioBuffer();
-      switch_mutex_unlock(tech_pvt->mutex);
+      /* mlk unlocks tech_pvt->mutex here as it goes out of scope */
     }
     return SWITCH_TRUE;
   }

--- a/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
+++ b/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
@@ -501,6 +501,21 @@ extern "C" {
     return SWITCH_STATUS_SUCCESS;
   }
 
+  void dg_transcribe_session_cleanup(void *pUserData) {
+    private_t* tech_pvt = (private_t*) pUserData;
+    if (!tech_pvt) return;
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+      "dg_transcribe_session_cleanup: tearing down orphaned tech_pvt (media bug never attached)\n");
+    switch_mutex_lock(tech_pvt->mutex);
+    /* the AudioPipe is already connecting (session_init calls connect());
+       hand it to the reaper, which finishes/closes it and deletes it once the
+       close promise is fulfilled -- finish() works pre-handshake via
+       m_gracefulShutdown, and CONNECT_FAIL fulfills the promise itself */
+    if (tech_pvt->pAudioPipe) reaper(tech_pvt);
+    destroy_tech_pvt(tech_pvt);
+    switch_mutex_unlock(tech_pvt->mutex);
+  }
+
 	switch_status_t dg_transcribe_session_stop(switch_core_session_t *session,int channelIsClosing, char* bugname) {
     switch_channel_t *channel = switch_core_session_get_channel(session);
     switch_media_bug_t *bug = (switch_media_bug_t*) switch_channel_get_private(channel, MY_BUG_NAME);

--- a/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
+++ b/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
@@ -585,7 +585,13 @@ extern "C" {
         frame.buflen = SWITCH_RECOMMENDED_BUFFER_SIZE;
         while (switch_core_media_bug_read(bug, &frame, SWITCH_TRUE) == SWITCH_STATUS_SUCCESS) {
           if (frame.datalen) {
-            spx_uint32_t out_len = available >> 1;  // space for samples which are 2 bytes
+            /* speex's interleaved API takes out_len in samples PER CHANNEL and
+               may write out_len * channels samples (2 bytes each). Sizing it as
+               available/2 ignored the channel count and let a stereo resample
+               write up to 2x the remaining ring-buffer space (heap overflow
+               past m_audio_buffer). Divide by bytes-per-frame instead; the
+               bytes_written accounting below already multiplies back. */
+            spx_uint32_t out_len = available / (2 * tech_pvt->channels);
             spx_uint32_t in_len = frame.samples;
 
             speex_resampler_process_interleaved_int(tech_pvt->resampler, 

--- a/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
+++ b/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
@@ -317,10 +317,14 @@ namespace {
               // The AudioPipe is NOT cleared here; it stays valid until the reaper
               // deletes it during cleanup. dg_transcribe_frame gates on the
               // connection state, so it will not use a failed pipe.
+              /* lws passes a NULL error string for some connect failures (the
+                 AudioPipe forwards its `in` pointer as-is); streaming NULL into
+                 an ostream or %s is undefined behavior */
+              const char* reason = message ? message : "unknown";
               std::stringstream json;
-              json << "{\"reason\":\"" << message << "\"}";
+              json << "{\"reason\":\"" << reason << "\"}";
               tech_pvt->responseHandler(session, TRANSCRIBE_EVENT_CONNECT_FAIL, (char *) json.str().c_str(), tech_pvt->bugname, finished);
-              switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "connection failed: %s\n", message);
+              switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "connection failed: %s\n", reason);
             }
             break;
             case deepgram::AudioPipe::CONNECTION_DROPPED:

--- a/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
+++ b/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
@@ -105,7 +105,25 @@ namespace {
       return false;
   }
 
-  static const char* emptyTranscript = "{\"alternatives\":[{\"transcript\":\"\",\"confidence\":0.0,\"words\":[]}]}";
+  /* Walk a parsed deepgram payload counting "transcript" string fields and how
+     many are non-empty, across whatever nesting (channel.alternatives[],
+     multichannel channels[], utterances[]) the message uses. Used to discard a
+     message only when it carries transcripts and ALL of them are empty --
+     the previous whole-payload strstr against one exact serialization dropped
+     any message merely CONTAINING an empty first alternative, losing real
+     content in multi-alternative/multichannel results. */
+  static void countTranscripts(cJSON* node, int& total, int& nonEmpty) {
+    if (!node) return;
+    for (cJSON* child = node->child; child; child = child->next) {
+      if (child->string && 0 == strcmp(child->string, "transcript") &&
+          (child->type & 0xFF) == cJSON_String) {
+        total++;
+        if (child->valuestring && child->valuestring[0] != '\0') nonEmpty++;
+      }
+      int t = child->type & 0xFF;
+      if (t == cJSON_Object || t == cJSON_Array) countTranscripts(child, total, nonEmpty);
+    }
+  }
 
   // Hand the AudioPipe off to a detached thread that closes the connection,
   // waits for the lws CLOSED to be signalled, then deletes it (via the
@@ -337,13 +355,26 @@ namespace {
               switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "connection closed gracefully\n");
             break;
             case deepgram::AudioPipe::MESSAGE:
-              if( strstr(message, emptyTranscript)) {
+            {
+              bool discard = false;
+              cJSON* json = cJSON_Parse(message);
+              if (json) {
+                int total = 0, nonEmpty = 0;
+                countTranscripts(json, total, nonEmpty);
+                /* only messages that carry transcripts, all of them empty; a
+                   parse failure or transcript-free payload (e.g. Metadata) is
+                   forwarded untouched as before */
+                discard = (total > 0 && nonEmpty == 0);
+                cJSON_Delete(json);
+              }
+              if (discard) {
                 switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "discarding empty deepgram transcript\n");
               }
               else {
                 tech_pvt->responseHandler(session, TRANSCRIBE_EVENT_RESULTS, message, tech_pvt->bugname, finished);
                 switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "deepgram message: %s\n", message);
               }
+            }
             break;
 
             default:

--- a/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
+++ b/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
@@ -107,15 +107,24 @@ namespace {
 
   static const char* emptyTranscript = "{\"alternatives\":[{\"transcript\":\"\",\"confidence\":0.0,\"words\":[]}]}";
 
+  // Hand the AudioPipe off to a detached thread that closes the connection,
+  // waits for the lws CLOSED to be signalled, then deletes it (via the
+  // shared_ptr destructor). Must be called with tech_pvt->mutex held and only
+  // after the media bug has been removed, so no media-bug thread can still touch
+  // the pipe. sessionId/id are captured BY VALUE so the thread never dereferences
+  // tech_pvt after this returns (tech_pvt lives in the session pool and may be
+  // freed once the session tears down).
   static void reaper(private_t *tech_pvt) {
     std::shared_ptr<deepgram::AudioPipe> pAp;
     pAp.reset((deepgram::AudioPipe *)tech_pvt->pAudioPipe);
     tech_pvt->pAudioPipe = nullptr;
 
-    std::thread t([pAp, tech_pvt]{
+    std::string sessionId(tech_pvt->sessionId);
+    uint32_t id = tech_pvt->id;
+    std::thread t([pAp, sessionId, id]{
       pAp->finish();
       pAp->waitForClose();
-      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "%s (%u) got remote close\n", tech_pvt->sessionId, tech_pvt->id);
+      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "%s (%u) got remote close\n", sessionId.c_str(), id);
     });
     t.detach();
   }
@@ -305,23 +314,22 @@ namespace {
             break;
             case deepgram::AudioPipe::CONNECT_FAIL:
             {
-              // first thing: we can no longer access the AudioPipe
+              // The AudioPipe is NOT cleared here; it stays valid until the reaper
+              // deletes it during cleanup. dg_transcribe_frame gates on the
+              // connection state, so it will not use a failed pipe.
               std::stringstream json;
               json << "{\"reason\":\"" << message << "\"}";
-              tech_pvt->pAudioPipe = nullptr;
               tech_pvt->responseHandler(session, TRANSCRIBE_EVENT_CONNECT_FAIL, (char *) json.str().c_str(), tech_pvt->bugname, finished);
               switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "connection failed: %s\n", message);
             }
             break;
             case deepgram::AudioPipe::CONNECTION_DROPPED:
-              // first thing: we can no longer access the AudioPipe
-              tech_pvt->pAudioPipe = nullptr;
+              // pipe stays valid until the reaper; dg_transcribe_frame gates on state.
               tech_pvt->responseHandler(session, TRANSCRIBE_EVENT_DISCONNECT, NULL, tech_pvt->bugname, finished);
               switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "connection dropped from far end\n");
             break;
             case deepgram::AudioPipe::CONNECTION_CLOSED_GRACEFULLY:
-              // first thing: we can no longer access the AudioPipe
-              tech_pvt->pAudioPipe = nullptr;
+              // pipe stays valid until the reaper; dg_transcribe_frame gates on state.
               switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "connection closed gracefully\n");
             break;
             case deepgram::AudioPipe::MESSAGE:
@@ -507,8 +515,10 @@ extern "C" {
     if (pAudioPipe) reaper(tech_pvt);
     destroy_tech_pvt(tech_pvt);
     switch_mutex_unlock(tech_pvt->mutex);
-    switch_mutex_destroy(tech_pvt->mutex);
-    tech_pvt->mutex = nullptr;
+    // NB: tech_pvt->mutex was created from the session pool
+    // (switch_core_session_get_pool); it is owned by the pool and freed when the
+    // pool is destroyed. Do NOT switch_mutex_destroy() it here — that would be a
+    // double cleanup.
     switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "(%u) dg_transcribe_session_stop\n", id);
     return SWITCH_STATUS_SUCCESS;
   }

--- a/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
+++ b/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
@@ -167,7 +167,7 @@ namespace {
     }
 
     if (var = switch_channel_get_variable(channel, "DEEPGRAM_SPEECH_MODEL_VERSION")) {
-     oss <<  "&version";
+     oss <<  "&version=";
      oss <<  var;
     }
     oss <<  "&language=";
@@ -336,9 +336,12 @@ namespace {
     switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "path: %s\n", path.c_str());
 
     strncpy(tech_pvt->sessionId, switch_core_session_get_uuid(session), MAX_SESSION_ID);
+    tech_pvt->sessionId[MAX_SESSION_ID-1] = '\0';
     strncpy(tech_pvt->host, "api.deepgram.com", MAX_WS_URL_LEN);
+    tech_pvt->host[MAX_WS_URL_LEN-1] = '\0';
     tech_pvt->port = 443;
-    strncpy(tech_pvt->path, path.c_str(), MAX_PATH_LEN);    
+    strncpy(tech_pvt->path, path.c_str(), MAX_PATH_LEN);
+    tech_pvt->path[MAX_PATH_LEN-1] = '\0';
     tech_pvt->sampling = desiredSampling;
     tech_pvt->responseHandler = responseHandler;
     tech_pvt->channels = channels;
@@ -553,7 +556,7 @@ extern "C" {
 
             if (out_len > 0) {
               // bytes written = num samples * 2 * num channels
-              size_t bytes_written = out_len << tech_pvt->channels;
+              size_t bytes_written = out_len * 2 * tech_pvt->channels;
               pAudioPipe->binaryWritePtrAdd(bytes_written);
               available = pAudioPipe->binarySpaceAvailable();
               dirty = true;

--- a/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
+++ b/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
@@ -53,7 +53,7 @@ namespace {
   static int nAudioBufferSecs = std::max(1, std::min(requestedBufferSecs ? ::atoi(requestedBufferSecs) : 2, 5));
   static const char *requestedNumServiceThreads = std::getenv("MOD_AUDIO_FORK_SERVICE_THREADS");
   static unsigned int nServiceThreads = std::max(1, std::min(requestedNumServiceThreads ? ::atoi(requestedNumServiceThreads) : 1, 5));
-  static unsigned int idxCallCount = 0;
+  static std::atomic<unsigned int> idxCallCount{0};
   static uint32_t playCount = 0;
 
   /* deepgram model / tier defaults by language */

--- a/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
+++ b/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
@@ -372,6 +372,11 @@ namespace {
 
     strncpy(tech_pvt->sessionId, switch_core_session_get_uuid(session), MAX_SESSION_ID);
     tech_pvt->sessionId[MAX_SESSION_ID-1] = '\0';
+    /* previously never populated: every event went out with an empty
+       media-bugname header and the CLOSE-path stop cleared channel-private
+       key "" instead of the key the bug is actually stored under */
+    strncpy(tech_pvt->bugname, bugname ? bugname : MY_BUG_NAME, MAX_BUG_LEN);
+    tech_pvt->bugname[MAX_BUG_LEN] = '\0';
     strncpy(tech_pvt->host, "api.deepgram.com", MAX_WS_URL_LEN);
     tech_pvt->host[MAX_WS_URL_LEN-1] = '\0';
     tech_pvt->port = 443;
@@ -512,7 +517,12 @@ extern "C" {
       
     // close connection and get final responses
     switch_mutex_lock(tech_pvt->mutex);
-    switch_channel_set_private(channel, bugname, NULL);
+    /* the bug is stored under the fixed MY_BUG_NAME key (start_capture), and
+       that is also the key this function looked it up under above -- clearing
+       the caller-supplied bugname instead left a stale bug pointer under
+       MY_BUG_NAME for any custom name, which a later stop/start dereferenced
+       after switch_core_media_bug_remove had already destroyed the bug */
+    switch_channel_set_private(channel, MY_BUG_NAME, NULL);
     if (!channelIsClosing) switch_core_media_bug_remove(session, &bug);
 
     deepgram::AudioPipe *pAudioPipe = static_cast<deepgram::AudioPipe *>(tech_pvt->pAudioPipe);

--- a/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
+++ b/modules/mod_deepgram_transcribe/dg_transcribe_glue.cpp
@@ -130,8 +130,8 @@ namespace {
   }
 
   static void destroy_tech_pvt(private_t *tech_pvt) {
-    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "%s (%u) destroy_tech_pvt\n", tech_pvt->sessionId, tech_pvt->id);
     if (tech_pvt) {
+      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "%s (%u) destroy_tech_pvt\n", tech_pvt->sessionId, tech_pvt->id);
       if (tech_pvt->pAudioPipe) {
         deepgram::AudioPipe* p = (deepgram::AudioPipe *) tech_pvt->pAudioPipe;
         delete p;
@@ -524,11 +524,10 @@ extern "C" {
       return SWITCH_STATUS_FALSE;
     }
     private_t* tech_pvt = (private_t*) switch_core_media_bug_get_user_data(bug);
+    if (!tech_pvt) return SWITCH_STATUS_FALSE;
     uint32_t id = tech_pvt->id;
 
     switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "(%u) dg_transcribe_session_stop\n", id);
-
-    if (!tech_pvt) return SWITCH_STATUS_FALSE;
       
     // close connection and get final responses
     switch_mutex_lock(tech_pvt->mutex);

--- a/modules/mod_deepgram_transcribe/dg_transcribe_glue.h
+++ b/modules/mod_deepgram_transcribe/dg_transcribe_glue.h
@@ -6,6 +6,9 @@ switch_status_t dg_transcribe_cleanup();
 switch_status_t dg_transcribe_session_init(switch_core_session_t *session, responseHandler_t responseHandler, 
 		uint32_t samples_per_second, uint32_t channels, char* lang, int interim, char* bugname, void **ppUserData);
 switch_status_t dg_transcribe_session_stop(switch_core_session_t *session, int channelIsClosing, char* bugname);
+/* teardown for a tech_pvt whose media bug was never attached (bug-add failure):
+   reaps the already-connecting AudioPipe and frees the resampler */
+void dg_transcribe_session_cleanup(void *pUserData);
 switch_bool_t dg_transcribe_frame(switch_core_session_t *session, switch_media_bug_t *bug);
 
 #endif

--- a/modules/mod_deepgram_transcribe/mod_deepgram_transcribe.c
+++ b/modules/mod_deepgram_transcribe/mod_deepgram_transcribe.c
@@ -16,10 +16,13 @@ static switch_status_t do_stop(switch_core_session_t *session, char* bugname);
 
 static void responseHandler(switch_core_session_t* session, 
 	const char* eventName, const char * json, const char* bugname, int finished) {
-	switch_event_t *event;
+	switch_event_t *event = NULL;
 	switch_channel_t *channel = switch_core_session_get_channel(session);
 
-	switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, eventName);
+	if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, eventName) != SWITCH_STATUS_SUCCESS || !event) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "responseHandler failed to create event for subclass %s\n", eventName);
+		return;
+	}
 	switch_channel_event_set_data(channel, event);
 	switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "deepgram");
 	switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-session-finished", finished ? "true" : "false");
@@ -128,7 +131,8 @@ SWITCH_STANDARD_API(dg_transcribe_function)
 		argc = switch_separate_string(mycmd, ' ', argv, (sizeof(argv) / sizeof(argv[0])));
 	}
 
-	if (zstr(cmd) || 
+	if (zstr(cmd) ||
+      argc < 2 || zstr(argv[1]) ||
       (!strcasecmp(argv[1], "stop") && argc < 2) ||
       (!strcasecmp(argv[1], "start") && argc < 3) ||
       zstr(argv[0])) {

--- a/modules/mod_deepgram_transcribe/mod_deepgram_transcribe.c
+++ b/modules/mod_deepgram_transcribe/mod_deepgram_transcribe.c
@@ -95,6 +95,10 @@ static switch_status_t start_capture(switch_core_session_t *session, switch_medi
 		return SWITCH_STATUS_FALSE;
 	}
 	if ((status = switch_core_media_bug_add(session, "dg_transcribe", NULL, capture_callback, pUserData, 0, flags, &bug)) != SWITCH_STATUS_SUCCESS) {
+		/* session_init already created the tech_pvt and started the AudioPipe
+		   connecting; without this teardown both leaked (object + open WS
+		   connection) since no bug private exists for any later stop to find */
+		dg_transcribe_session_cleanup(pUserData);
 		return status;
 	}
   switch_channel_set_private(channel, MY_BUG_NAME, bug);

--- a/modules/mod_deepgram_transcribe/mod_deepgram_transcribe.c
+++ b/modules/mod_deepgram_transcribe/mod_deepgram_transcribe.c
@@ -140,7 +140,8 @@ SWITCH_STANDARD_API(dg_transcribe_function)
       (!strcasecmp(argv[1], "stop") && argc < 2) ||
       (!strcasecmp(argv[1], "start") && argc < 3) ||
       zstr(argv[0])) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s %s.\n", cmd, argv[0], argv[1]);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s %s.\n",
+			cmd ? cmd : "", argv[0] ? argv[0] : "", argv[1] ? argv[1] : "");
 		stream->write_function(stream, "-USAGE: %s\n", TRANSCRIBE_API_SYNTAX);
 		goto done;
 	} else {

--- a/modules/mod_deepgram_transcribe/simple_buffer.h
+++ b/modules/mod_deepgram_transcribe/simple_buffer.h
@@ -1,15 +1,16 @@
 /**
- * (very) simple and limited circular buffer, 
+ * (very) simple and limited circular buffer,
  * supporting only the use case of doing all of the adds
  * and then subsquently retrieves.
- * 
+ *
  */
 class SimpleBuffer {
   public:
     SimpleBuffer(uint32_t chunkSize, uint32_t numChunks) : numItems(0),
-    m_numChunks(numChunks), m_chunkSize(chunkSize) {
+    m_chunkSize(chunkSize), m_numChunks(numChunks) {
       m_pData = new char[chunkSize * numChunks];
       m_pNextWrite = m_pData;
+      m_pNextRead = m_pData;
     }
     ~SimpleBuffer() {
       delete [] m_pData;
@@ -21,23 +22,32 @@ class SimpleBuffer {
       for (int i = 0; i < numChunks; i++) {
         memcpy(m_pNextWrite, data, m_chunkSize);
         data = static_cast<char*>(data) + m_chunkSize;
-        if (numItems < m_numChunks) numItems++;
 
         uint32_t offset = (m_pNextWrite - m_pData) / m_chunkSize;
         if (offset >= m_numChunks - 1) m_pNextWrite = m_pData;
         else m_pNextWrite += m_chunkSize;
+
+        if (numItems < m_numChunks) {
+          numItems++;
+        }
+        else {
+          // buffer was full: the oldest chunk was just overwritten, so advance
+          // the read cursor to keep it pointing at the new oldest chunk.
+          uint32_t roffset = (m_pNextRead - m_pData) / m_chunkSize;
+          if (roffset >= m_numChunks - 1) m_pNextRead = m_pData;
+          else m_pNextRead += m_chunkSize;
+        }
       }
     }
 
     char* getNextChunk() {
-      if (numItems--) {
-        char *p = m_pNextWrite;
-        uint32_t offset = (m_pNextWrite - m_pData) / m_chunkSize;
-        if (offset >= m_numChunks - 1) m_pNextWrite = m_pData;
-        else m_pNextWrite += m_chunkSize;
-        return p;
-      }
-      return nullptr;
+      if (numItems == 0) return nullptr;
+      numItems--;
+      char *p = m_pNextRead;
+      uint32_t offset = (m_pNextRead - m_pData) / m_chunkSize;
+      if (offset >= m_numChunks - 1) m_pNextRead = m_pData;
+      else m_pNextRead += m_chunkSize;
+      return p;
     }
 
     uint32_t getNumItems() { return numItems;}
@@ -48,4 +58,5 @@ class SimpleBuffer {
     uint32_t m_chunkSize;
     uint32_t m_numChunks;
     char* m_pNextWrite;
+    char* m_pNextRead;
 };

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -369,16 +369,33 @@ public:
         }
       } while (p);
     }
+    if (!m_prebufStaging.empty()) {
+      /* flush the sub-chunk staging remainder, in order (m_connected is true
+         here, so this takes the direct Write path, any length) */
+      write(m_prebufStaging.data(), (uint32_t) m_prebufStaging.size());
+      m_prebufStaging.clear();
+      m_prebufStaging.shrink_to_fit();
+    }
   }
 
 	bool write(void* data, uint32_t datalen) {
     if (!m_connected) {
-      if (datalen % CHUNKSIZE == 0) {
-        // lazily allocate the prebuffer: only the VAD path writes before connect()
-        if (!m_audioBuffer) {
-          m_audioBuffer.reset(new SimpleBuffer(CHUNKSIZE, PREBUFFER_CHUNKS));
-        }
-        m_audioBuffer->add(data, datalen);
+      // lazily allocate the prebuffer: only the VAD path writes before connect()
+      if (!m_audioBuffer) {
+        m_audioBuffer.reset(new SimpleBuffer(CHUNKSIZE, PREBUFFER_CHUNKS));
+      }
+      /* SimpleBuffer stores fixed CHUNKSIZE slices and its add() rejects
+         other lengths -- non-multiple frames (30ms-ptime codecs, resampler
+         output on the VAD path) were dropped wholesale. Stage bytes and feed
+         whole chunks; connect() flushes the remainder after the drain.
+         Single-threaded here: the VAD path's write() and connect() both run
+         on the media thread under cb->mutex. */
+      const uint8_t* p = static_cast<const uint8_t*>(data);
+      m_prebufStaging.insert(m_prebufStaging.end(), p, p + datalen);
+      size_t usable = (m_prebufStaging.size() / CHUNKSIZE) * CHUNKSIZE;
+      if (usable) {
+        m_audioBuffer->add(m_prebufStaging.data(), (uint32_t) usable);
+        m_prebufStaging.erase(m_prebufStaging.begin(), m_prebufStaging.begin() + usable);
       }
       return true;
     }
@@ -466,6 +483,8 @@ private:
   std::mutex m_write_mutex;  // serializes all m_streamer write-side ops (Write/WritesDone)
   std::promise<void> m_promise;
   std::unique_ptr<SimpleBuffer> m_audioBuffer;  // lazily allocated; only used on the VAD prebuffer path
+  /* sub-chunk staging for the pre-connect path; media-thread-only (cb->mutex) */
+  std::vector<uint8_t> m_prebufStaging;
 };
 
 static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *obj) {

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -537,13 +537,20 @@ extern "C" {
 
       switch_channel_t *channel = switch_core_session_get_channel(session);
       auto read_codec = switch_core_session_get_read_codec(session);
+      if (!read_codec || !read_codec->implementation) {
+        switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR,
+          "google_speech_session_init: no read codec/implementation available\n");
+        return SWITCH_STATUS_FALSE;
+      }
       uint32_t sampleRate = read_codec->implementation->actual_samples_per_second;
       struct cap_cb *cb;
       int err;
 
       cb =(struct cap_cb *) switch_core_session_alloc(session, sizeof(*cb));
       strncpy(cb->sessionId, switch_core_session_get_uuid(session), MAX_SESSION_ID);
+      cb->sessionId[MAX_SESSION_ID] = '\0';
       strncpy(cb->bugname, bugname, MAX_BUG_LEN);
+      cb->bugname[MAX_BUG_LEN] = '\0';
       cb->got_end_of_utterance = 0;
       cb->wants_single_utterance = single_utterance;
       if (play_file != NULL){
@@ -556,6 +563,10 @@ extern "C" {
         if (0 != err) {
            switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s: Error initializing resampler: %s.\n",
                                  switch_channel_get_name(channel), speex_resampler_strerror(err));
+          if (cb->resampler) {
+            speex_resampler_destroy(cb->resampler);
+            cb->resampler = NULL;
+          }
           return SWITCH_STATUS_FALSE;
         }
       } else {

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -655,12 +655,15 @@ extern "C" {
     switch_status_t google_speech_init() {
       const char* gcsServiceKeyFile = std::getenv("GOOGLE_APPLICATION_CREDENTIALS");
       if (gcsServiceKeyFile) {
-        try {
-          auto creds = grpc::GoogleDefaultCredentials();
-        } catch (const std::exception& e) {
-          switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, 
-            "Error initializing google api with provided credentials in %s: %s\n", gcsServiceKeyFile, e.what());
-          return SWITCH_STATUS_FALSE;
+        /* GoogleDefaultCredentials never throws -- it returns a null
+           shared_ptr on failure (grpc secure_credentials.cc), so the previous
+           try/catch was a no-op that could not catch anything. Check the
+           pointer and warn; module load proceeds either way (credentials can
+           also be supplied per-channel). */
+        auto creds = grpc::GoogleDefaultCredentials();
+        if (!creds) {
+          switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+            "GOOGLE_APPLICATION_CREDENTIALS (%s) did not yield usable default credentials; transcribe starts relying on them will fail\n", gcsServiceKeyFile);
         }
       }
       return SWITCH_STATUS_SUCCESS;
@@ -749,8 +752,18 @@ extern "C" {
          profanity_filter, word_time_offset, punctuation, model, enhanced, hints);
         cb->streamer.store(streamer);
       } catch (std::exception& e) {
-        switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s: Error initializing gstreamer: %s.\n", 
+        switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s: Error initializing gstreamer: %s.\n",
           switch_channel_get_name(channel), e.what());
+        /* the resampler and vad were allocated above and cleanup never runs
+           for a failed init (no bug is ever added) -- free them here */
+        if (cb->resampler) {
+          speex_resampler_destroy(cb->resampler);
+          cb->resampler = NULL;
+        }
+        if (cb->vad) {
+          switch_vad_destroy(&cb->vad);
+          cb->vad = nullptr;
+        }
         return SWITCH_STATUS_FALSE;
       }
 

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -115,15 +115,33 @@ public:
     if (!(google_uri = switch_channel_get_variable(channel, "GOOGLE_SPEECH_TO_TEXT_URI"))) {
       google_uri = "speech.googleapis.com";
     }
+		/* HTTP/2 keepalive: without it a silent network partition leaves the
+		   read thread blocked in Read() and cleanup's WritesDone() blocked in
+		   Pluck() with no deadline -- stop/hangup then stalls for the TCP
+		   failure-detection duration (minutes). Pings only while the call is
+		   active; a healthy long-running stream is unaffected. */
+		grpc::ChannelArguments channelArgs;
+		channelArgs.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 60000);
+		channelArgs.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 20000);
+		channelArgs.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 0);
+
 		if ((var = switch_channel_get_variable(channel, "GOOGLE_APPLICATION_CREDENTIALS"))) {
 			auto channelCreds = grpc::SslCredentials(grpc::SslCredentialsOptions());
 			auto callCreds = grpc::ServiceAccountJWTAccessCredentials(var);
+			if (!callCreds) {
+				/* an invalid JSON key (e.g. the channel var set to a file PATH,
+				   matching the env var convention of the same name) yields a null
+				   shared_ptr, and CompositeChannelCredentials dereferences it with
+				   no guard (grpc v1.60 secure_credentials.cc) -- a segfault the
+				   session_init catch cannot stop. Fail catchably instead. */
+				throw std::invalid_argument("GOOGLE_APPLICATION_CREDENTIALS channel variable is not a valid service-account JSON key (note: unlike the env var, it must contain the key itself, not a file path)");
+			}
 			auto creds = grpc::CompositeChannelCredentials(channelCreds, callCreds);
-			m_channel = grpc::CreateChannel(google_uri, creds);
+			m_channel = grpc::CreateCustomChannel(google_uri, creds, channelArgs);
 		}
 		else {
 			auto creds = grpc::GoogleDefaultCredentials();
-			m_channel = grpc::CreateChannel(google_uri, creds);
+			m_channel = grpc::CreateCustomChannel(google_uri, creds, channelArgs);
 		}
 
   	m_stub = Speech::NewStub(m_channel);

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <future>
 #include <memory>
+#include <mutex>
 
 #include <switch.h>
 #include <switch_json.h>
@@ -323,7 +324,12 @@ public:
     m_promise.set_value();
 
   	// Write the first request, containing the config only.
-  	m_streamer->Write(m_request);
+  	// gRPC requires all write-side ops (Write + WritesDone) on a stream to be
+  	// externally serialized; m_write_mutex serializes them across threads.
+  	{
+  	  std::lock_guard<std::mutex> lk(m_write_mutex);
+  	  m_streamer->Write(m_request);
+  	}
 
     // send any buffered audio (only the VAD path ever fills m_audioBuffer)
     int nFrames = m_audioBuffer ? m_audioBuffer->getNumItems() : 0;
@@ -351,6 +357,7 @@ public:
       return true;
     }
     m_request.set_audio_content(data, datalen);
+    std::lock_guard<std::mutex> lk(m_write_mutex);
     bool ok = m_streamer->Write(m_request);
     return ok;
   }
@@ -375,6 +382,7 @@ public:
       cancelConnect();
     }
     else if (!m_writesDone) {
+      std::lock_guard<std::mutex> lk(m_write_mutex);
       m_streamer->WritesDone();
       m_writesDone = true;
     }
@@ -404,6 +412,7 @@ private:
 	StreamingRecognizeRequest m_request;
   bool m_writesDone;
   bool m_connected;
+  std::mutex m_write_mutex;  // serializes all m_streamer write-side ops (Write/WritesDone)
   std::promise<void> m_promise;
   std::unique_ptr<SimpleBuffer> m_audioBuffer;  // lazily allocated; only used on the VAD prebuffer path
 };

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -559,6 +559,34 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
   return nullptr;
 }
 
+/* Shared teardown: half-close (or cancel) the stream, join the read thread,
+   delete the streamer, free resampler/vad. Caller must hold cb->mutex (or own
+   the cb exclusively, as on the never-attached path). Idempotent: safe when
+   another path already ran it. */
+static void reap_streamer(struct cap_cb* cb) {
+  GStreamer* streamer = (GStreamer *) cb->streamer.load();
+  if (streamer) {
+    streamer->writesDone();
+  }
+  if (cb->thread) {
+    switch_status_t st;
+    switch_thread_join(&st, cb->thread);
+    cb->thread = NULL;
+  }
+  if (streamer) {
+    delete streamer;
+    cb->streamer.store(NULL);
+  }
+  if (cb->resampler) {
+    speex_resampler_destroy(cb->resampler);
+    cb->resampler = NULL;
+  }
+  if (cb->vad) {
+    switch_vad_destroy(&cb->vad);
+    cb->vad = nullptr;
+  }
+}
+
 extern "C" {
 
     switch_status_t google_speech_init() {
@@ -676,6 +704,20 @@ extern "C" {
       return SWITCH_STATUS_SUCCESS;
     }
 
+    /* teardown for a cap_cb whose media bug was never attached (bug-add
+       failure): the read thread is already running -- blocked in
+       waitForConnect() on the VAD path or reading on the connected path --
+       and it lives in the session pool, so leaving it running is a
+       use-after-free once the session is destroyed */
+    void google_speech_session_orphan_cleanup(void *pUserData) {
+      struct cap_cb *cb = (struct cap_cb *) pUserData;
+      if (!cb) return;
+      switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+        "google_speech_session_orphan_cleanup: tearing down orphaned cb %p (media bug never attached)\n", (void *) cb);
+      MutexLock cbLock(cb->mutex);
+      reap_streamer(cb);
+    }
+
     switch_status_t google_speech_session_cleanup(switch_core_session_t *session, int channelIsClosing, switch_media_bug_t *bug) {
       switch_channel_t *channel = switch_core_session_get_channel(session);
 
@@ -684,8 +726,15 @@ extern "C" {
         MutexLock cbLock(cb->mutex);  // unlocks on any exit from this scope
 
         if (!switch_channel_get_private(channel, cb->bugname)) {
-          // race condition
-          switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "%s Bug is not attached (race).\n", switch_channel_get_name(channel));
+          // The private is already gone: either a benign double-cleanup of THIS
+          // cb (streamer/thread already reaped -- reap_streamer is a no-op), or
+          // this cb LOST a start race (a second start under the same bugname
+          // overwrote the private) and nothing else will ever tear it down.
+          // Unconditionally skipping the join here orphaned the loser's read
+          // thread, which lives in the session pool and dereferenced freed
+          // memory after session destroy.
+          switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "%s Bug is not attached (race); reaping this bug's own resources.\n", switch_channel_get_name(channel));
+          reap_streamer(cb);
           return SWITCH_STATUS_FALSE;
         }
         switch_channel_set_private(channel, cb->bugname, NULL);
@@ -699,28 +748,12 @@ extern "C" {
         	}
         }
 
-        // close connection and get final responses
-        GStreamer* streamer = (GStreamer *) cb->streamer.load();
+        // close connection and get final responses (writesDone + join read
+        // thread + delete streamer + free resampler/vad)
+        switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "google_speech_session_cleanup: waiting for read thread to complete\n");
+        reap_streamer(cb);
+        switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "google_speech_session_cleanup: read thread completed\n");
 
-        if (streamer) {
-          streamer->writesDone();
-
-          switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "google_speech_session_cleanup: GStreamer (%p) waiting for read thread to complete\n", (void*)streamer);
-          switch_status_t st;
-          switch_thread_join(&st, cb->thread);
-          switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "google_speech_session_cleanup:  GStreamer (%p) read thread completed\n", (void*)streamer);
-
-          delete streamer;
-          cb->streamer.store(NULL);
-        }
-
-        if (cb->resampler) {
-          speex_resampler_destroy(cb->resampler);
-        }
-        if (cb->vad) {
-          switch_vad_destroy(&cb->vad);
-          cb->vad = nullptr;
-        }
         if (!channelIsClosing) {
           switch_core_media_bug_remove(session, &bug);
         }

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -684,6 +684,7 @@ extern "C" {
       cb->bugname[MAX_BUG_LEN] = '\0';
       cb->got_end_of_utterance = 0;
       cb->wants_single_utterance = single_utterance;
+      cb->channels = channels;
       if (play_file != NULL){
         cb->play_file = 1;
       }
@@ -856,7 +857,9 @@ extern "C" {
 
               if (cb->resampler) {
                 spx_int16_t out[SWITCH_RECOMMENDED_BUFFER_SIZE];
-                spx_uint32_t out_len = SWITCH_RECOMMENDED_BUFFER_SIZE;
+                /* interleaved API: capacity and counts are samples PER CHANNEL;
+                   out[] holds SWITCH_RECOMMENDED_BUFFER_SIZE elements total */
+                spx_uint32_t out_len = SWITCH_RECOMMENDED_BUFFER_SIZE / cb->channels;
                 spx_uint32_t in_len = frame.samples;
                 size_t written;
 
@@ -865,10 +868,14 @@ extern "C" {
                   (spx_uint32_t *) &in_len,
                   &out[0],
                   &out_len);
-                streamer->write( &out[0], sizeof(spx_int16_t) * out_len);
+                /* out_len is per-channel samples; bytes = samples * 2 * channels */
+                streamer->write( &out[0], sizeof(spx_int16_t) * out_len * cb->channels);
               }
               else {
-                streamer->write( frame.data, sizeof(spx_int16_t) * frame.samples);
+                /* frame.samples is per-channel (media_bug_read divides by the
+                   channel count); frame.datalen is the actual byte count --
+                   sizeof(int16) * samples sent only HALF of every stereo frame */
+                streamer->write( frame.data, frame.datalen);
               }
             }
           }

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -227,9 +227,11 @@ public:
       auto *context = config->add_speech_contexts();
       float boost = -1;
 
-      // get boost setting for the phrase set in its entirety
-      if (switch_true(switch_channel_get_variable(channel, "GOOGLE_SPEECH_HINTS_BOOST"))) {
-     	  boost = (float) atof(switch_channel_get_variable(channel, "GOOGLE_SPEECH_HINTS_BOOST"));
+      // get boost setting for the phrase set in its entirety. Gate on the var
+      // being SET, not switch_true(): fractional boosts ("0.5") atoi to 0 and
+      // were silently ignored, while "true"-ish garbage passed and set 0.0.
+      if ((var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_HINTS_BOOST"))) {
+     	  boost = (float) atof(var);
         switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "boost value: %f\n", boost);
         phrase_set->set_boost(boost);
       }
@@ -241,10 +243,16 @@ public:
         int i = 0;
         cJSON *jPhrase = NULL;
         cJSON_ArrayForEach(jPhrase, jHint) {
-          auto* phrase = phrase_set->add_phrases();
           cJSON *jItem = cJSON_GetObjectItem(jPhrase, "phrase");
-          if (jItem) {
-            phrase->set_value(cJSON_GetStringValue(jItem));
+          /* cJSON_GetStringValue returns NULL for a non-string "phrase"
+             ([{"phrase":123}]) and protobuf set_value(const char*) would
+             construct std::string from NULL -- crash on operator-provided
+             config. Also stop add_phrases()ing empty entries for objects
+             with no usable phrase. */
+          const char* sPhrase = jItem ? cJSON_GetStringValue(jItem) : NULL;
+          if (sPhrase) {
+            auto* phrase = phrase_set->add_phrases();
+            phrase->set_value(sPhrase);
             switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "phrase: %s\n", phrase->value().c_str());
             if (cJSON_GetObjectItem(jPhrase, "boost")) {
               phrase->set_boost((float) cJSON_GetObjectItem(jPhrase, "boost")->valuedouble);

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -410,8 +410,14 @@ private:
 	std::unique_ptr<Speech::Stub> 	m_stub;
 	std::unique_ptr< grpc::ClientReaderWriterInterface<StreamingRecognizeRequest, StreamingRecognizeResponse> > m_streamer;
 	StreamingRecognizeRequest m_request;
-  bool m_writesDone;
-  bool m_connected;
+  // m_writesDone and m_connected are read/written across the media (frame)
+  // thread, the gRPC read thread, and the cleanup thread without a shared lock
+  // (e.g. writesDone() is called from both the gRPC read thread and cleanup; a
+  // VAD-path connect() on the media thread can run concurrently with cleanup's
+  // writesDone()). They are atomics to make those accesses race-free; a mutex
+  // is avoided because cleanup joins the read thread while it may be writing.
+  std::atomic<bool> m_writesDone;
+  std::atomic<bool> m_connected;
   std::mutex m_write_mutex;  // serializes all m_streamer write-side ops (Write/WritesDone)
   std::promise<void> m_promise;
   std::unique_ptr<SimpleBuffer> m_audioBuffer;  // lazily allocated; only used on the VAD prebuffer path
@@ -419,7 +425,7 @@ private:
 
 static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *obj) {
 	struct cap_cb *cb = (struct cap_cb *) obj;
-	GStreamer* streamer = (GStreamer *) cb->streamer;
+	GStreamer* streamer = (GStreamer *) cb->streamer.load();
 
   bool connected = streamer->waitForConnect();
   if (!connected) {
@@ -649,7 +655,7 @@ extern "C" {
       try {
         streamer = new GStreamer(session, channels, lang, interim, to_rate, sampleRate, single_utterance, separate_recognition, max_alternatives,
          profanity_filter, word_time_offset, punctuation, model, enhanced, hints);
-        cb->streamer = streamer;
+        cb->streamer.store(streamer);
       } catch (std::exception& e) {
         switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "%s: Error initializing gstreamer: %s.\n", 
           switch_channel_get_name(channel), e.what());
@@ -694,7 +700,7 @@ extern "C" {
         }
 
         // close connection and get final responses
-        GStreamer* streamer = (GStreamer *) cb->streamer;
+        GStreamer* streamer = (GStreamer *) cb->streamer.load();
 
         if (streamer) {
           streamer->writesDone();
@@ -705,7 +711,7 @@ extern "C" {
           switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "google_speech_session_cleanup:  GStreamer (%p) read thread completed\n", (void*)streamer);
 
           delete streamer;
-          cb->streamer = NULL;
+          cb->streamer.store(NULL);
         }
 
         if (cb->resampler) {
@@ -732,15 +738,24 @@ extern "C" {
     switch_bool_t google_speech_frame(switch_media_bug_t *bug, void* user_data) {
     	switch_core_session_t *session = switch_core_media_bug_get_session(bug);
     	struct cap_cb *cb = (struct cap_cb *) user_data;
-		  if (cb->streamer && (!cb->wants_single_utterance || !cb->got_end_of_utterance)) {
-        GStreamer* streamer = (GStreamer *) cb->streamer;
+		  // single atomic load of streamer; reused for both the gate and the cast so
+		  // the pointer cannot change between the null-check and the dereference.
+		  GStreamer* streamer = (GStreamer *) cb->streamer.load();
+		  if (streamer && (!cb->wants_single_utterance || !cb->got_end_of_utterance)) {
         uint8_t data[SWITCH_RECOMMENDED_BUFFER_SIZE];
         switch_frame_t frame = {};
         frame.data = data;
         frame.buflen = SWITCH_RECOMMENDED_BUFFER_SIZE;
 
         if (switch_mutex_trylock(cb->mutex) == SWITCH_STATUS_SUCCESS) {
-          while (switch_core_media_bug_read(bug, &frame, SWITCH_TRUE) == SWITCH_STATUS_SUCCESS && !switch_test_flag((&frame), SFF_CNG)) {
+          // Re-read streamer UNDER the lock. google_speech_session_cleanup deletes
+          // the GStreamer and nulls cb->streamer while holding cb->mutex, so the
+          // pointer obtained here stays valid for the whole locked region (the
+          // pre-lock load at the top of the function is only a fast-path hint and
+          // could be stale/freed by a concurrent do_stop). Gating the loop on it
+          // means a concurrent delete is observed as NULL -> no use-after-free.
+          streamer = (GStreamer *) cb->streamer.load();
+          while (streamer && switch_core_media_bug_read(bug, &frame, SWITCH_TRUE) == SWITCH_STATUS_SUCCESS && !switch_test_flag((&frame), SFF_CNG)) {
             if (frame.datalen) {
               if (cb->vad && !streamer->isConnected()) {
                 switch_vad_state_t state = switch_vad_process(cb->vad, (int16_t*) frame.data, frame.samples);

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -571,6 +571,24 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
           cb->responseHandler(session, "no_audio", cb->bugname);
         }
       }
+      else if (!status.ok()) {
+        /* the RPC failure status (UNAUTHENTICATED, UNAVAILABLE,
+           INVALID_ARGUMENT, RESOURCE_EXHAUSTED, ...) arrives HERE, not as an
+           in-band response error -- previously only OUT_OF_RANGE was surfaced
+           and every other failure produced a DEBUG log and silence, leaving
+           the consumer waiting on a recognizer that was gone. Same event
+           shape as the in-band error path above. */
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "grpc_read_thread: stream failed: %s (%d)\n", status.error_message().c_str(), status.error_code());
+        cJSON* json = cJSON_CreateObject();
+        cJSON_AddStringToObject(json, "type", "error");
+        cJSON_AddStringToObject(json, "error", status.error_message().c_str());
+        char* jsonString = cJSON_PrintUnformatted(json);
+        if (jsonString) {
+          cb->responseHandler(session, jsonString, cb->bugname);
+          free(jsonString);
+        }
+        cJSON_Delete(json);
+      }
       switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "grpc_read_thread: finish() status %s (%d)\n", status.error_message().c_str(), status.error_code()) ;
     }
     // sessionLock releases the session read-lock here at scope exit

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <algorithm>
 #include <future>
+#include <memory>
 
 #include <switch.h>
 #include <switch_json.h>
@@ -45,7 +46,10 @@ using google::cloud::speech::v1p1beta1::RecognitionMetadata_RecordingDeviceType_
 using google::cloud::speech::v1p1beta1::StreamingRecognizeResponse_SpeechEventType_END_OF_SINGLE_UTTERANCE;
 using google::rpc::Status;
 
-#define CHUNKSIZE (320)
+#define CHUNKSIZE (320)  /* bytes per audio chunk: 320 = 160 samples = 20ms @ 8kHz, 16-bit mono (L16) */
+
+/* number of CHUNKSIZE chunks to pre-buffer while waiting for the gRPC stream to connect (VAD path) */
+#define PREBUFFER_CHUNKS (15)
 
 namespace {
   int case_insensitive_match(std::string s1, std::string s2) {
@@ -55,6 +59,32 @@ namespace {
       return 1; //The strings are same
    return 0; //not matched
   }
+
+  // RAII guard for switch_core_session_locate / switch_core_session_rwunlock.
+  // Locates the session on construction; releases the read-lock on destruction
+  // (any scope exit). get() returns nullptr if the session could not be located.
+  class SessionLock {
+  public:
+    explicit SessionLock(const char* sessionId) : m_session(switch_core_session_locate(sessionId)) {}
+    ~SessionLock() { if (m_session) switch_core_session_rwunlock(m_session); }
+    SessionLock(const SessionLock&) = delete;
+    SessionLock& operator=(const SessionLock&) = delete;
+    switch_core_session_t* get() const { return m_session; }
+  private:
+    switch_core_session_t* m_session;
+  };
+
+  // RAII guard for switch_mutex_lock / switch_mutex_unlock around scopes with
+  // multiple exits. Locks on construction, unlocks on destruction.
+  class MutexLock {
+  public:
+    explicit MutexLock(switch_mutex_t* mutex) : m_mutex(mutex) { switch_mutex_lock(m_mutex); }
+    ~MutexLock() { switch_mutex_unlock(m_mutex); }
+    MutexLock(const MutexLock&) = delete;
+    MutexLock& operator=(const MutexLock&) = delete;
+  private:
+    switch_mutex_t* m_mutex;
+  };
 }
 class GStreamer;
 
@@ -75,8 +105,7 @@ public:
     int punctuation, 
     const char* model, 
     int enhanced, 
-		const char* hints) : m_session(session), m_writesDone(false), m_connected(false), 
-      m_audioBuffer(CHUNKSIZE, 15) {
+		const char* hints) : m_session(session), m_writesDone(false), m_connected(false) {
   
     const char* var;
     const char* google_uri;
@@ -85,7 +114,7 @@ public:
     if (!(google_uri = switch_channel_get_variable(channel, "GOOGLE_SPEECH_TO_TEXT_URI"))) {
       google_uri = "speech.googleapis.com";
     }
-		if (var = switch_channel_get_variable(channel, "GOOGLE_APPLICATION_CREDENTIALS")) {
+		if ((var = switch_channel_get_variable(channel, "GOOGLE_APPLICATION_CREDENTIALS"))) {
 			auto channelCreds = grpc::SslCredentials(grpc::SslCredentialsOptions());
 			auto callCreds = grpc::ServiceAccountJWTAccessCredentials(var);
 			auto creds = grpc::CompositeChannelCredentials(channelCreds, callCreds);
@@ -220,7 +249,7 @@ public:
     }
 
     // alternative language
-    if (var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_ALTERNATIVE_LANGUAGE_CODES")) {
+    if ((var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_ALTERNATIVE_LANGUAGE_CODES"))) {
       char *alt_langs[3] = { 0 };
       int argc = switch_separate_string((char *) var, ',', alt_langs, 3);
       for (int i = 0; i < argc; i++) {
@@ -230,16 +259,16 @@ public:
     }
 
     // speaker diarization
-    if (var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_SPEAKER_DIARIZATION")) {
+    if ((var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_SPEAKER_DIARIZATION"))) {
       auto* diarization_config = config->mutable_diarization_config();
       diarization_config->set_enable_speaker_diarization(true);
       switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "enabling speaker diarization\n", var);
-      if (var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_SPEAKER_DIARIZATION_MIN_SPEAKER_COUNT")) {
+      if ((var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_SPEAKER_DIARIZATION_MIN_SPEAKER_COUNT"))) {
         int count = std::max(atoi(var), 1);
         switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "setting min speaker count to %d\n", count);
         diarization_config->set_min_speaker_count(count);
       }
-      if (var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_SPEAKER_DIARIZATION_MAX_SPEAKER_COUNT")) {
+      if ((var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_SPEAKER_DIARIZATION_MAX_SPEAKER_COUNT"))) {
         int count = std::max(atoi(var), 2);
         switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(m_session), SWITCH_LOG_DEBUG, "setting max speaker count to %d\n", count);
         diarization_config->set_max_speaker_count(count);
@@ -248,7 +277,7 @@ public:
 
     // recognition metadata
     auto* metadata = config->mutable_metadata();
-    if (var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_METADATA_INTERACTION_TYPE")) {
+    if ((var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_METADATA_INTERACTION_TYPE"))) {
       if (case_insensitive_match("discussion", var)) metadata->set_interaction_type(RecognitionMetadata_InteractionType_DISCUSSION);
       if (case_insensitive_match("presentation", var)) metadata->set_interaction_type(RecognitionMetadata_InteractionType_PRESENTATION);
       if (case_insensitive_match("phone_call", var)) metadata->set_interaction_type(RecognitionMetadata_InteractionType_PHONE_CALL);
@@ -258,19 +287,19 @@ public:
       if (case_insensitive_match("voice_command", var)) metadata->set_interaction_type(RecognitionMetadata_InteractionType_VOICE_COMMAND);
       if (case_insensitive_match("dictation", var)) metadata->set_interaction_type(RecognitionMetadata_InteractionType_DICTATION);
     }
-    if (var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_METADATA_INDUSTRY_NAICS_CODE")) {
+    if ((var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_METADATA_INDUSTRY_NAICS_CODE"))) {
       metadata->set_industry_naics_code_of_audio(atoi(var));
     }
-    if (var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_METADATA_MICROPHONE_DISTANCE")) {
+    if ((var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_METADATA_MICROPHONE_DISTANCE"))) {
       if (case_insensitive_match("nearfield", var)) metadata->set_microphone_distance(RecognitionMetadata_MicrophoneDistance_NEARFIELD);
       if (case_insensitive_match("midfield", var)) metadata->set_microphone_distance(RecognitionMetadata_MicrophoneDistance_MIDFIELD);
       if (case_insensitive_match("farfield", var)) metadata->set_microphone_distance(RecognitionMetadata_MicrophoneDistance_FARFIELD);
     }
-    if (var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_METADATA_ORIGINAL_MEDIA_TYPE")) {
+    if ((var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_METADATA_ORIGINAL_MEDIA_TYPE"))) {
       if (case_insensitive_match("audio", var)) metadata->set_original_media_type(RecognitionMetadata_OriginalMediaType_AUDIO);
       if (case_insensitive_match("video", var)) metadata->set_original_media_type(RecognitionMetadata_OriginalMediaType_VIDEO);
     }
-    if (var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_METADATA_RECORDING_DEVICE_TYPE")) {
+    if ((var = switch_channel_get_variable(channel, "GOOGLE_SPEECH_METADATA_RECORDING_DEVICE_TYPE"))) {
       if (case_insensitive_match("smartphone", var)) metadata->set_recording_device_type(RecognitionMetadata_RecordingDeviceType_SMARTPHONE);
       if (case_insensitive_match("pc", var)) metadata->set_recording_device_type(RecognitionMetadata_RecordingDeviceType_PC);
       if (case_insensitive_match("phone_line", var)) metadata->set_recording_device_type(RecognitionMetadata_RecordingDeviceType_PHONE_LINE);
@@ -296,13 +325,13 @@ public:
   	// Write the first request, containing the config only.
   	m_streamer->Write(m_request);
 
-    // send any buffered audio
-    int nFrames = m_audioBuffer.getNumItems();
-    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p got stream ready, %d buffered frames\n", this, nFrames);	
+    // send any buffered audio (only the VAD path ever fills m_audioBuffer)
+    int nFrames = m_audioBuffer ? m_audioBuffer->getNumItems() : 0;
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "GStreamer %p got stream ready, %d buffered frames\n", this, nFrames);
     if (nFrames) {
       char *p;
       do {
-        p = m_audioBuffer.getNextChunk();
+        p = m_audioBuffer->getNextChunk();
         if (p) {
           write(p, CHUNKSIZE);
         }
@@ -313,7 +342,11 @@ public:
 	bool write(void* data, uint32_t datalen) {
     if (!m_connected) {
       if (datalen % CHUNKSIZE == 0) {
-        m_audioBuffer.add(data, datalen);
+        // lazily allocate the prebuffer: only the VAD path writes before connect()
+        if (!m_audioBuffer) {
+          m_audioBuffer.reset(new SimpleBuffer(CHUNKSIZE, PREBUFFER_CHUNKS));
+        }
+        m_audioBuffer->add(data, datalen);
       }
       return true;
     }
@@ -372,11 +405,10 @@ private:
   bool m_writesDone;
   bool m_connected;
   std::promise<void> m_promise;
-  SimpleBuffer m_audioBuffer;
+  std::unique_ptr<SimpleBuffer> m_audioBuffer;  // lazily allocated; only used on the VAD prebuffer path
 };
 
 static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *obj) {
-  static int count;
 	struct cap_cb *cb = (struct cap_cb *) obj;
 	GStreamer* streamer = (GStreamer *) cb->streamer;
 
@@ -389,12 +421,12 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
   // Read responses.
   StreamingRecognizeResponse response;
   while (streamer->read(&response)) {  // Returns false when no more to read.
-    switch_core_session_t* session = switch_core_session_locate(cb->sessionId);
+    SessionLock sessionLock(cb->sessionId);
+    switch_core_session_t* session = sessionLock.get();
     if (!session) {
       switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "grpc_read_thread: session %s is gone!\n", cb->sessionId) ;
       return nullptr;
     }
-    count++;
     auto speech_event_type = response.speech_event_type();
     if (response.has_error()) {
       Status status = response.error();
@@ -413,7 +445,7 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
     }
     
     for (int r = 0; r < response.results_size(); ++r) {
-      auto result = response.results(r);
+      const auto& result = response.results(r);
       cJSON * jResult = cJSON_CreateObject();
       cJSON * jAlternatives = cJSON_CreateArray();
       cJSON * jStability = cJSON_CreateNumber(result.stability());
@@ -435,7 +467,7 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
       cJSON_AddItemToObject(jResult, "result_end_time", jResultEndTime);
 
       for (int a = 0; a < result.alternatives_size(); ++a) {
-        auto alternative = result.alternatives(a);
+        const auto& alternative = result.alternatives(a);
         cJSON* jAlt = cJSON_CreateObject();
         cJSON* jConfidence = cJSON_CreateNumber(alternative.confidence());
         cJSON* jTranscript = cJSON_CreateString(alternative.transcript().c_str());
@@ -446,7 +478,7 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
           cJSON * jWords = cJSON_CreateArray();
           switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "grpc_read_thread: %d words\n", alternative.words_size()) ;
           for (int b = 0; b < alternative.words_size(); b++) {
-            auto words = alternative.words(b);
+            const auto& words = alternative.words(b);
             cJSON* jWord = cJSON_CreateObject();
             cJSON_AddItemToObject(jWord, "word", cJSON_CreateString(words.word().c_str()));
             if (words.has_start_time()) {
@@ -488,12 +520,13 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
         streamer->writesDone();
       }
     }
-    switch_core_session_rwunlock(session);
     switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "grpc_read_thread: got %d responses\n", response.results_size());
+    // sessionLock releases the session read-lock here at scope exit
   }
 
   {
-    switch_core_session_t* session = switch_core_session_locate(cb->sessionId);
+    SessionLock sessionLock(cb->sessionId);
+    switch_core_session_t* session = sessionLock.get();
     if (session) {
       grpc::Status status = streamer->finish();
       if (11 == status.error_code()) {
@@ -505,8 +538,8 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
         }
       }
       switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "grpc_read_thread: finish() status %s (%d)\n", status.error_message().c_str(), status.error_code()) ;
-      switch_core_session_rwunlock(session);
     }
+    // sessionLock releases the session read-lock here at scope exit
   }
   return nullptr;
 }
@@ -584,16 +617,16 @@ extern "C" {
           int voice_ms = 250;
           int debug = 0;
 
-          if (var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_MODE")) {
+          if ((var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_MODE"))) {
             mode = atoi(var);
           }
-          if (var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_SILENCE_MS")) {
+          if ((var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_SILENCE_MS"))) {
             silence_ms = atoi(var);
           }
-          if (var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_VOICE_MS")) {
+          if ((var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_VOICE_MS"))) {
             voice_ms = atoi(var);
           }
-          if (var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_VOICE_MS")) {
+          if ((var = switch_channel_get_variable(channel, "RECOGNIZER_VAD_VOICE_MS"))) {
             voice_ms = atoi(var);
           }
           switch_vad_set_mode(cb->vad, mode);
@@ -633,12 +666,11 @@ extern "C" {
 
       if (bug) {
         struct cap_cb *cb = (struct cap_cb *) switch_core_media_bug_get_user_data(bug);
-        switch_mutex_lock(cb->mutex);
+        MutexLock cbLock(cb->mutex);  // unlocks on any exit from this scope
 
         if (!switch_channel_get_private(channel, cb->bugname)) {
           // race condition
           switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "%s Bug is not attached (race).\n", switch_channel_get_name(channel));
-          switch_mutex_unlock(cb->mutex);
           return SWITCH_STATUS_FALSE;
         }
         switch_channel_set_private(channel, cb->bugname, NULL);
@@ -680,9 +712,7 @@ extern "C" {
 
 			  switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "google_speech_session_cleanup: Closed stream\n");
 
-			  switch_mutex_unlock(cb->mutex);
-
-
+			  // cbLock unlocks cb->mutex here at scope exit
 			  return SWITCH_STATUS_SUCCESS;
       }
 

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -381,10 +381,17 @@ public:
     if (!m_connected) {
       cancelConnect();
     }
-    else if (!m_writesDone) {
+    else {
+      /* the flag must be re-checked UNDER the lock: the gRPC read thread
+         (END_OF_SINGLE_UTTERANCE) and the stop/hangup cleanup thread can both
+         reach here concurrently -- with the check outside the lock both passed
+         it, then serialized on the mutex and each issued WritesDone(), the
+         double half-close this function's own comment says crashes grpc */
       std::lock_guard<std::mutex> lk(m_write_mutex);
-      m_streamer->WritesDone();
-      m_writesDone = true;
+      if (!m_writesDone) {
+        m_streamer->WritesDone();
+        m_writesDone = true;
+      }
     }
 	}
 

--- a/modules/mod_google_transcribe/google_glue.cpp
+++ b/modules/mod_google_transcribe/google_glue.cpp
@@ -358,6 +358,11 @@ public:
     }
     m_request.set_audio_content(data, datalen);
     std::lock_guard<std::mutex> lk(m_write_mutex);
+    /* re-check under the lock: after WritesDone()/Finish() the stream is
+       half-closed and a further Write violates the gRPC API contract (the
+       END_OF_SINGLE_UTTERANCE gate in the frame callback is only checked once,
+       before its read loop, so the read thread can half-close mid-loop) */
+    if (m_writesDone) return false;
     bool ok = m_streamer->Write(m_request);
     return ok;
   }
@@ -373,6 +378,13 @@ public:
 	}
 
 	grpc::Status finish() {
+		/* gRPC sync streams document Write/WritesDone as thread-safe only with
+		   respect to Read -- NOT Finish. The media thread can still be inside
+		   write() when google unilaterally ends the stream and the read thread
+		   calls finish(); serialize them on the same mutex, and mark the write
+		   side closed so no Write can follow Finish. */
+		std::lock_guard<std::mutex> lk(m_write_mutex);
+		m_writesDone = true;
 		return m_streamer->Finish();
 	}
 

--- a/modules/mod_google_transcribe/google_glue.h
+++ b/modules/mod_google_transcribe/google_glue.h
@@ -8,6 +8,9 @@ switch_status_t google_speech_session_init(switch_core_session_t *session, respo
 		int separate_recognition, int max_alternatives, int profinity_filter, int word_time_offset, int punctuation, const char* model, int enhanced, 
 		const char* hints, char* play_file, void **ppUserData);
 switch_status_t google_speech_session_cleanup(switch_core_session_t *session, int channelIsClosing, switch_media_bug_t *bug);
+/* teardown for a cap_cb whose media bug was never attached (bug-add failure):
+   joins the already-running gRPC read thread and deletes the streamer */
+void google_speech_session_orphan_cleanup(void *pUserData);
 switch_bool_t google_speech_frame(switch_media_bug_t *bug, void* user_data);
 
 #endif

--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -21,36 +21,54 @@ static switch_status_t do_stop(switch_core_session_t *session, char* bugname);
 
 
 static void responseHandler(switch_core_session_t* session, const char * json, const char* bugname) {
-	switch_event_t *event;
+	switch_event_t *event = NULL;
 	switch_channel_t *channel = switch_core_session_get_channel(session);
 
 	if (0 == strcmp("vad_detected", json)) {
-		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_VAD_DETECTED);
+		if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_VAD_DETECTED) != SWITCH_STATUS_SUCCESS || !event) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "failed to create event subclass %s\n", TRANSCRIBE_EVENT_VAD_DETECTED);
+			return;
+		}
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "google");
 	}
 	else if (0 == strcmp("end_of_utterance", json)) {
-		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_END_OF_UTTERANCE);
+		if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_END_OF_UTTERANCE) != SWITCH_STATUS_SUCCESS || !event) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "failed to create event subclass %s\n", TRANSCRIBE_EVENT_END_OF_UTTERANCE);
+			return;
+		}
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "google");
 	}
 	else if (0 == strcmp("end_of_transcript", json)) {
-		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_END_OF_TRANSCRIPT);
+		if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_END_OF_TRANSCRIPT) != SWITCH_STATUS_SUCCESS || !event) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "failed to create event subclass %s\n", TRANSCRIBE_EVENT_END_OF_TRANSCRIPT);
+			return;
+		}
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "google");
 	}
 	else if (0 == strcmp("start_of_transcript", json)) {
-		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_START_OF_TRANSCRIPT);
+		if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_START_OF_TRANSCRIPT) != SWITCH_STATUS_SUCCESS || !event) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "failed to create event subclass %s\n", TRANSCRIBE_EVENT_START_OF_TRANSCRIPT);
+			return;
+		}
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "google");
 	}
 	else if (0 == strcmp("max_duration_exceeded", json)) {
-		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_MAX_DURATION_EXCEEDED);
+		if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_MAX_DURATION_EXCEEDED) != SWITCH_STATUS_SUCCESS || !event) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "failed to create event subclass %s\n", TRANSCRIBE_EVENT_MAX_DURATION_EXCEEDED);
+			return;
+		}
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "google");
 	}
 	else if (0 == strcmp("no_audio", json)) {
-		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_NO_AUDIO_DETECTED);
+		if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_NO_AUDIO_DETECTED) != SWITCH_STATUS_SUCCESS || !event) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "failed to create event subclass %s\n", TRANSCRIBE_EVENT_NO_AUDIO_DETECTED);
+			return;
+		}
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "google");
 	}
@@ -64,7 +82,10 @@ static void responseHandler(switch_core_session_t* session, const char * json, c
 		}else{
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "unable to create play inturrupt event \n");
 		}
-		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_PLAY_INTERRUPT);
+		if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_PLAY_INTERRUPT) != SWITCH_STATUS_SUCCESS || !event) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "failed to create event subclass %s\n", TRANSCRIBE_EVENT_PLAY_INTERRUPT);
+			return;
+		}
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "google");
 	}
@@ -83,10 +104,16 @@ static void responseHandler(switch_core_session_t* session, const char * json, c
     		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_RESULTS);
     }
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "%s json payload: %s.\n", bugname ? bugname : "google_transcribe", json);
+		if (!event) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "failed to create event subclass %s\n",
+				error ? TRANSCRIBE_EVENT_ERROR : TRANSCRIBE_EVENT_RESULTS);
+			return;
+		}
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "transcription-vendor", "google");
 		switch_event_add_body(event, "%s", json);
 	}
+	if (!event) return;
 	if (bugname) switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "media-bugname", bugname);
 	switch_event_fire(&event);
 }
@@ -300,8 +327,8 @@ SWITCH_STANDARD_API(transcribe2_function)
 		argc = switch_separate_string(mycmd, ' ', argv, (sizeof(argv) / sizeof(argv[0])));
 	}
 
-	if (zstr(cmd) || 
-      (argc < 2) ||
+	if (zstr(cmd) ||
+      (argc < 2) || !argv[1] ||
       (!strcasecmp(argv[1], "start") && argc < 10) ||
       zstr(argv[0])) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s.\n", cmd, argv[0]);
@@ -368,7 +395,8 @@ SWITCH_STANDARD_API(transcribe_function)
 		argc = switch_separate_string(mycmd, ' ', argv, (sizeof(argv) / sizeof(argv[0])));
 	}
 
-	if (zstr(cmd) || 
+	if (zstr(cmd) ||
+      (argc < 2) || !argv[1] ||
       (!strcasecmp(argv[1], "stop") && argc < 2) ||
       (!strcasecmp(argv[1], "start") && argc < 3) ||
       zstr(argv[0])) {
@@ -477,7 +505,6 @@ SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_transcribe_shutdown)
 	switch_event_free_subclass(TRANSCRIBE_EVENT_END_OF_TRANSCRIPT);
 	switch_event_free_subclass(TRANSCRIBE_EVENT_NO_AUDIO_DETECTED);
 	switch_event_free_subclass(TRANSCRIBE_EVENT_MAX_DURATION_EXCEEDED);
-	switch_event_free_subclass(TRANSCRIBE_EVENT_END_OF_UTTERANCE);
 	switch_event_free_subclass(TRANSCRIBE_EVENT_PLAY_INTERRUPT);
 	return SWITCH_STATUS_SUCCESS;
 }

--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -359,8 +359,13 @@ SWITCH_STANDARD_API(transcribe2_function)
 				if (argc > 10) {
 					sample_rate = atol(argv[10]);
 				}
+				/* model (argv[11]) and enhanced (argv[12]) gated separately: the
+			   combined argc > 12 gate silently ignored a model supplied as the
+			   12th argument without an enhanced flag after it */
+				if (argc > 11){
+					model = argv[11]; // model
+				}
 				if (argc > 12){
-					model = argv[11]; // model 
 					enhanced = !strcmp(argv[12], "true"); // enhanced
 				}
 				if (argc > 13){

--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -240,6 +240,15 @@ static switch_status_t start_capture(switch_core_session_t *session, switch_medi
   const char* model = NULL;
 	const char* var;
 
+	if (strlen(bugname) > MAX_BUG_LEN) {
+		/* the channel private is stored under the FULL name but cb->bugname is
+		   a truncated copy used by the CLOSE-path stop -- a longer name made
+		   cleanup miss the private and orphan the gRPC read thread */
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+			"bugname too long (max %d chars): %s\n", MAX_BUG_LEN, bugname);
+		return SWITCH_STATUS_FALSE;
+	}
+
 	if (switch_channel_get_private(channel, bugname)) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "removing bug from previous transcribe\n");
 		do_stop(session, bugname);
@@ -337,7 +346,8 @@ SWITCH_STANDARD_API(transcribe2_function)
       (argc < 2) || !argv[1] ||
       (!strcasecmp(argv[1], "start") && argc < 10) ||
       zstr(argv[0])) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s.\n", cmd, argv[0]);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s.\n",
+			cmd ? cmd : "", argv[0] ? argv[0] : "");
 		stream->write_function(stream, "-USAGE: %s\n", TRANSCRIBE2_API_SYNTAX);
 		goto done;
 	} else {
@@ -411,7 +421,8 @@ SWITCH_STANDARD_API(transcribe_function)
       (!strcasecmp(argv[1], "stop") && argc < 2) ||
       (!strcasecmp(argv[1], "start") && argc < 3) ||
       zstr(argv[0])) {
-		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s %s.\n", cmd, argv[0], argv[1]);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error with command %s %s %s.\n",
+			cmd ? cmd : "", argv[0] ? argv[0] : "", argv[1] ? argv[1] : "");
 		stream->write_function(stream, "-USAGE: %s\n", TRANSCRIBE_API_SYNTAX);
 		goto done;
 	} else {

--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -103,7 +103,7 @@ static void responseHandler(switch_core_session_t* session, const char * json, c
     if (!error) {
     		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, TRANSCRIBE_EVENT_RESULTS);
     }
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "%s json payload: %s.\n", bugname ? bugname : "google_transcribe", json);
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "%s json payload: %s.\n", bugname ? bugname : "google_transcribe", json);
 		if (!event) {
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "failed to create event subclass %s\n",
 				error ? TRANSCRIBE_EVENT_ERROR : TRANSCRIBE_EVENT_RESULTS);
@@ -472,6 +472,10 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_transcribe_load)
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", TRANSCRIBE_EVENT_PLAY_INTERRUPT);
 		return SWITCH_STATUS_TERM;
 	}
+	if (switch_event_reserve_subclass(TRANSCRIBE_EVENT_VAD_DETECTED) != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", TRANSCRIBE_EVENT_VAD_DETECTED);
+		return SWITCH_STATUS_TERM;
+	}
 
 	/* connect my internal structure to the blank pointer passed to me */
 	*module_interface = switch_loadable_module_create_module_interface(pool, modname);
@@ -506,6 +510,7 @@ SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_transcribe_shutdown)
 	switch_event_free_subclass(TRANSCRIBE_EVENT_NO_AUDIO_DETECTED);
 	switch_event_free_subclass(TRANSCRIBE_EVENT_MAX_DURATION_EXCEEDED);
 	switch_event_free_subclass(TRANSCRIBE_EVENT_PLAY_INTERRUPT);
+	switch_event_free_subclass(TRANSCRIBE_EVENT_VAD_DETECTED);
 	return SWITCH_STATUS_SUCCESS;
 }
 

--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -209,10 +209,13 @@ static switch_status_t start_capture2(switch_core_session_t *session, switch_med
 		return SWITCH_STATUS_FALSE;
 	}
 	if ((status = switch_core_media_bug_add(session, "google_transcribe", NULL, capture_callback, pUserData, 0, flags, &bug)) != SWITCH_STATUS_SUCCESS) {
+		/* the gRPC read thread is already running out of the session pool;
+		   without this teardown it outlives session destroy (use-after-free) */
+		google_speech_session_orphan_cleanup(pUserData);
 		return status;
 	}
 
-	switch_channel_set_private(channel, MY_BUG_NAME, bug);	
+	switch_channel_set_private(channel, MY_BUG_NAME, bug);
 
 	/* play the prompt, looking for detection result */
 	if (play_file != NULL){
@@ -301,6 +304,9 @@ static switch_status_t start_capture(switch_core_session_t *session, switch_medi
 	}
 
 	if ((status = switch_core_media_bug_add(session, bugname, NULL, capture_callback, pUserData, 0, flags, &bug)) != SWITCH_STATUS_SUCCESS) {
+		/* the gRPC read thread is already running out of the session pool;
+		   without this teardown it outlives session destroy (use-after-free) */
+		google_speech_session_orphan_cleanup(pUserData);
 		return status;
 	}
 

--- a/modules/mod_google_transcribe/mod_google_transcribe.h
+++ b/modules/mod_google_transcribe/mod_google_transcribe.h
@@ -47,6 +47,7 @@ struct cap_cb {
 	char bugname[MAX_BUG_LEN+1];
 	char sessionId[MAX_SESSION_ID+1];
 	char *base;
+	uint32_t channels;   /* capture channel count (2 with SMBF_STEREO) */
   SpeexResamplerState *resampler;
 	/* streamer is read by the media (frame) thread at the gate BEFORE the
 	 * trylock, while cleanup nulls it under cb->mutex after switch_thread_join.

--- a/modules/mod_google_transcribe/mod_google_transcribe.h
+++ b/modules/mod_google_transcribe/mod_google_transcribe.h
@@ -6,6 +6,10 @@
 
 #include <unistd.h>
 
+#ifdef __cplusplus
+#include <atomic>
+#endif
+
 #define MAX_SESSION_ID (256)
 #define MAX_BUG_LEN (64)
 #define MY_BUG_NAME "google_transcribe"
@@ -44,11 +48,32 @@ struct cap_cb {
 	char sessionId[MAX_SESSION_ID+1];
 	char *base;
   SpeexResamplerState *resampler;
+	/* streamer is read by the media (frame) thread at the gate BEFORE the
+	 * trylock, while cleanup nulls it under cb->mutex after switch_thread_join.
+	 * That gate read is unsynchronized against the cleanup store, so it is a
+	 * lock-free atomic pointer (avoids the cleanup/thread_join deadlock a mutex
+	 * would cause). Touched ONLY from google_glue.cpp (C++); std::atomic<void*>
+	 * is lock-free and same-sized as void*, so the C ABI view and the
+	 * zeroed-alloc layout are unchanged. */
+#ifdef __cplusplus
+	std::atomic<void*> streamer;
+#else
 	void* streamer;
+#endif
 	responseHandler_t responseHandler;
 	switch_thread_t* thread;
   int wants_single_utterance;
+  /* got_end_of_utterance is written by the gRPC read thread and read by the
+   * media (frame) thread with no shared lock. A mutex here would deadlock
+   * (cleanup holds cb->mutex across switch_thread_join vs the read thread), so
+   * it is a lock-free atomic. It is touched ONLY from google_glue.cpp (C++);
+   * the .c view stays a plain int and std::atomic<int> is layout-compatible
+   * with int, so struct size/layout is unchanged. */
+#ifdef __cplusplus
+  std::atomic<int> got_end_of_utterance;
+#else
   int got_end_of_utterance;
+#endif
 	int play_file;
 	switch_vad_t * vad;
 	uint32_t samples_per_second;

--- a/modules/mod_google_transcribe/simple_buffer.h
+++ b/modules/mod_google_transcribe/simple_buffer.h
@@ -1,15 +1,16 @@
 /**
- * (very) simple and limited circular buffer, 
+ * (very) simple and limited circular buffer,
  * supporting only the use case of doing all of the adds
  * and then subsquently retrieves.
- * 
+ *
  */
 class SimpleBuffer {
   public:
     SimpleBuffer(uint32_t chunkSize, uint32_t numChunks) : numItems(0),
-    m_numChunks(numChunks), m_chunkSize(chunkSize) {
+    m_chunkSize(chunkSize), m_numChunks(numChunks) {
       m_pData = new char[chunkSize * numChunks];
       m_pNextWrite = m_pData;
+      m_pNextRead = m_pData;
     }
     ~SimpleBuffer() {
       delete [] m_pData;
@@ -21,23 +22,32 @@ class SimpleBuffer {
       for (int i = 0; i < numChunks; i++) {
         memcpy(m_pNextWrite, data, m_chunkSize);
         data = static_cast<char*>(data) + m_chunkSize;
-        if (numItems < m_numChunks) numItems++;
 
         uint32_t offset = (m_pNextWrite - m_pData) / m_chunkSize;
         if (offset >= m_numChunks - 1) m_pNextWrite = m_pData;
         else m_pNextWrite += m_chunkSize;
+
+        if (numItems < m_numChunks) {
+          numItems++;
+        }
+        else {
+          // buffer was full: the oldest chunk was just overwritten, so advance
+          // the read cursor to keep it pointing at the new oldest chunk.
+          uint32_t roffset = (m_pNextRead - m_pData) / m_chunkSize;
+          if (roffset >= m_numChunks - 1) m_pNextRead = m_pData;
+          else m_pNextRead += m_chunkSize;
+        }
       }
     }
 
     char* getNextChunk() {
-      if (numItems--) {
-        char *p = m_pNextWrite;
-        uint32_t offset = (m_pNextWrite - m_pData) / m_chunkSize;
-        if (offset >= m_numChunks - 1) m_pNextWrite = m_pData;
-        else m_pNextWrite += m_chunkSize;
-        return p;
-      }
-      return nullptr;
+      if (numItems == 0) return nullptr;
+      numItems--;
+      char *p = m_pNextRead;
+      uint32_t offset = (m_pNextRead - m_pData) / m_chunkSize;
+      if (offset >= m_numChunks - 1) m_pNextRead = m_pData;
+      else m_pNextRead += m_chunkSize;
+      return p;
     }
 
     uint32_t getNumItems() { return numItems;}
@@ -48,4 +58,5 @@ class SimpleBuffer {
     uint32_t m_chunkSize;
     uint32_t m_numChunks;
     char* m_pNextWrite;
+    char* m_pNextRead;
 };

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,7 +6,12 @@
 #
 #   make            # build + run tests
 #   make coverage   # build + run + gcov; prints HOST_COVERAGE=<pct>%
+#   make sanitize   # build + run under AddressSanitizer + UndefinedBehaviorSanitizer
 #   make clean
+#
+# NOTE: `sanitize` exercises only the FreeSWITCH-independent units. True ASan/TSan
+# of the modules' threading needs a sanitizer build of the module + a live call
+# (see SANITIZERS.md) — it cannot be done from this host harness.
 #
 # The repo's quality gate parses the HOST_COVERAGE line. This coverage figure is
 # for the host-testable units ONLY — it is NOT repo-wide or module coverage.
@@ -26,10 +31,24 @@ TESTS     = test_base64 test_simple_buffer
 BINS      = $(addprefix $(BUILD)/,$(TESTS))
 COV_SRCS  = base64.hpp simple_buffer.h
 
-.PHONY: test coverage clean
+.PHONY: test coverage sanitize clean
 
 test: $(BINS)
 	@set -e; for b in $(BINS); do echo "== $$b =="; ./$$b; done
+
+# AddressSanitizer + UndefinedBehaviorSanitizer (+ leak detection) on the
+# host-testable units. Built separately (no coverage flags) so the sanitizer
+# runtime isn't perturbed by gcov instrumentation.
+SANFLAGS = -fsanitize=address,undefined -fno-omit-frame-pointer
+sanitize: | $(BUILD)
+	@set -e; \
+	$(CXX) -std=c++11 -g -O1 $(SANFLAGS) -I$(AUDIOFORK) -o $(BUILD)/test_base64_san test_base64.cpp; \
+	$(CXX) -std=c++11 -g -O1 $(SANFLAGS) -I$(DEEPGRAM) -o $(BUILD)/test_simple_buffer_san test_simple_buffer.cpp; \
+	echo "== ASan/UBSan: test_base64 =="; \
+	ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=print_stacktrace=1 $(BUILD)/test_base64_san; \
+	echo "== ASan/UBSan: test_simple_buffer =="; \
+	ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=print_stacktrace=1 $(BUILD)/test_simple_buffer_san; \
+	echo "ASan/UBSan: clean (no sanitizer errors)"
 
 $(BUILD):
 	@mkdir -p $(BUILD)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,70 @@
+# Host-side unit tests for FreeSWITCH-independent logic.
+#
+# These do NOT build any FreeSWITCH module. They compile the pure, header-only
+# units (base64.hpp, SimpleBuffer) on the host with coverage instrumentation so
+# the logic that does not need the FreeSWITCH runtime can actually be tested.
+#
+#   make            # build + run tests
+#   make coverage   # build + run + gcov; prints HOST_COVERAGE=<pct>%
+#   make clean
+#
+# The repo's quality gate parses the HOST_COVERAGE line. This coverage figure is
+# for the host-testable units ONLY — it is NOT repo-wide or module coverage.
+
+CXX      ?= g++
+CXXFLAGS ?= -std=c++11 -g -O0 -Wall -Wextra
+COVFLAGS  = --coverage
+BUILD     = build
+
+# simple_buffer.h is shared by the four callBroadcast-utilized transcribe modules.
+# base64.hpp is not used by those four; it lives in mod_audio_fork (tested here as
+# general repo coverage, with a note that it is outside the utilized set).
+DEEPGRAM  = ../modules/mod_deepgram_transcribe
+AUDIOFORK = ../modules/mod_audio_fork
+
+TESTS     = test_base64 test_simple_buffer
+BINS      = $(addprefix $(BUILD)/,$(TESTS))
+COV_SRCS  = base64.hpp simple_buffer.h
+
+.PHONY: test coverage clean
+
+test: $(BINS)
+	@set -e; for b in $(BINS); do echo "== $$b =="; ./$$b; done
+
+$(BUILD):
+	@mkdir -p $(BUILD)
+
+$(BUILD)/test_base64.o: test_base64.cpp test_util.h | $(BUILD)
+	$(CXX) $(CXXFLAGS) $(COVFLAGS) -I$(AUDIOFORK) -c -o $@ test_base64.cpp
+
+$(BUILD)/test_simple_buffer.o: test_simple_buffer.cpp test_util.h | $(BUILD)
+	$(CXX) $(CXXFLAGS) $(COVFLAGS) -I$(DEEPGRAM) -c -o $@ test_simple_buffer.cpp
+
+$(BUILD)/test_base64: $(BUILD)/test_base64.o
+	$(CXX) $(COVFLAGS) -o $@ $^
+
+$(BUILD)/test_simple_buffer: $(BUILD)/test_simple_buffer.o
+	$(CXX) $(COVFLAGS) -o $@ $^
+
+coverage: test
+	@gcov -r -o $(BUILD) test_base64.cpp test_simple_buffer.cpp >/dev/null 2>&1 || true
+	@echo "--- host coverage (FreeSWITCH-independent units) ---"
+	@total=0; covered=0; \
+	for h in $(COV_SRCS); do \
+	  g=$$(ls $$h.gcov 2>/dev/null | head -n1); \
+	  if [ -n "$$g" ]; then \
+	    c=$$(grep -cE '^[[:space:]]*[0-9]+:' "$$g"); \
+	    n=$$(grep -cE '^[[:space:]]*#####:' "$$g"); \
+	    tot=$$((c + n)); \
+	    if [ $$tot -gt 0 ]; then pct=$$(awk -v c=$$c -v t=$$tot 'BEGIN{printf "%.1f", 100*c/t}'); \
+	      else pct="n/a"; fi; \
+	    printf '  %-18s %s%% (%s/%s lines)\n' "$$h" "$$pct" "$$c" "$$tot"; \
+	    covered=$$((covered + c)); total=$$((total + tot)); \
+	  else printf '  %-18s no gcov data\n' "$$h"; fi; \
+	done; \
+	if [ $$total -gt 0 ]; then \
+	  awk -v c=$$covered -v t=$$total 'BEGIN{printf "HOST_COVERAGE=%.1f%%\n", 100*c/t}'; \
+	else echo "HOST_COVERAGE=n/a"; fi
+
+clean:
+	@rm -rf $(BUILD) *.gcov

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,28 @@
+# Host unit tests
+
+Tests for the FreeSWITCH-**independent** logic in the modules — the only code
+that can be compiled and exercised without the FreeSWITCH source tree and the
+vendor SDKs (libwebsockets, gRPC, AWS, Azure).
+
+Currently covered:
+
+- `base64.hpp` — `drachtio::base64_encode` / `base64_decode` (RFC 4648 vectors,
+  full-byte round-trip, buffer/string overloads).
+- `simple_buffer.h` — `SimpleBuffer` FIFO (partial-fill read order, empty-buffer
+  underflow guard, multi-chunk add, non-multiple rejection, full-buffer overwrite
+  order). These pin the behavior of the fixed circular buffer.
+
+```sh
+make            # build + run
+make coverage   # build + run + gcov; prints HOST_COVERAGE=<pct>%
+make clean
+```
+
+`HOST_COVERAGE` is the line coverage of the host-testable units **only**. It is
+not module coverage and not repo-wide coverage — the modules themselves build
+only inside the FreeSWITCH tree and are not measured here.
+
+Module *glue* (`*_glue.cpp`, `mod_*.c`) is **not** host-testable: it depends on
+`switch_core_*`, media bugs, and live vendor streams. Do not mock the FreeSWITCH
+core to fake coverage — test the pure logic, and verify glue behavior in a real
+FreeSWITCH build.

--- a/tests/SANITIZERS.md
+++ b/tests/SANITIZERS.md
@@ -1,0 +1,78 @@
+# Sanitizing the modules (ASan / UBSan / TSan)
+
+There are two distinct things, and they cover different code:
+
+## 1. Host harness — runnable anywhere (no FreeSWITCH, no creds)
+
+`make -C tests sanitize` builds the FreeSWITCH-independent units (`base64`,
+`SimpleBuffer`) with **ASan + UBSan** and runs them. This catches buffer
+overruns, use-after-free, and undefined behavior **in that logic only**. It does
+**not** touch the modules' threading — `SimpleBuffer` has no internal locking
+(callers lock), so it is single-threaded here and TSan adds nothing.
+
+Status: clean.
+
+## 2. The modules' threading — needs a live FreeSWITCH + a real call
+
+The media-bug thread, the websocket/gRPC/SDK threads, and the teardown/reaper
+path only run concurrently during an actual transcription call. So real ASan/TSan
+results require **building the module with sanitizers inside the FreeSWITCH tree
+and exercising it with live calls** (vendor credentials required). Loading the
+module without a call exercises ~none of the concurrency — TSan would report
+"clean" trivially (a false negative). Do not trust a sanitizer run that didn't
+make calls.
+
+### Build flags
+
+Append to the per-module compile/link in the installer's `install_mod_*` recipe
+(`callBroadcast/freeswitch/install-freeswitch-debian-trixie.sh`):
+
+- **ASan + UBSan** (memory safety, UAF, UB):
+  `-fsanitize=address,undefined -fno-omit-frame-pointer -g`
+  (add to both the per-file compiles and the final `-shared` link).
+- **TSan** (data races) — build the module with:
+  `-fsanitize=thread -fno-omit-frame-pointer -g`
+  TSan is most reliable when the **whole process** is instrumented; ideally also
+  build FreeSWITCH (and libwebsockets) with `-fsanitize=thread`. With only the
+  module instrumented you still get reports for races that touch module code, but
+  expect some noise and false negatives across the un-instrumented boundary.
+
+Do ASan and TSan in **separate** builds (they are mutually exclusive).
+
+### Running
+
+Start FreeSWITCH so the sanitizer runtime loads with the module. If FS itself was
+not built with the sanitizer, preload it:
+
+    ASAN_OPTIONS=detect_leaks=1:halt_on_error=0:log_path=/tmp/asan \
+      LD_PRELOAD=$(gcc -print-file-name=libasan.so) \
+      /usr/local/freeswitch/bin/freeswitch -nonat -nc
+
+    # TSan build:
+    TSAN_OPTIONS=halt_on_error=0:second_deadlock_stack=1:log_path=/tmp/tsan \
+      /usr/local/freeswitch/bin/freeswitch -nonat -nc
+
+### Scenarios to exercise (the soak)
+
+Per vendor (deepgram/google/aws/azure — needs that vendor's creds) and for
+mod_audio_fork (needs a ws sink), run each and watch /tmp/asan.* and /tmp/tsan.*:
+
+1. Start transcription, stream audio, normal stop.
+2. **Far-end drop mid-call** (kill the vendor/ws connection while audio flows).
+3. **Graceful stop** while streaming.
+4. **Hangup mid-call** (channel teardown while connected) — exercises the reaper.
+5. **Rapid start/stop** churn.
+6. **Connect failure** (bad host/creds) — exercises the CONNECT_FAIL path.
+7. Sustained back-pressure (aws): confirm the bounded deque drops oldest
+   (`AWS_TRANSCRIBE_MAX_BUFFERED_FRAMES`) rather than growing.
+
+### Caveats
+
+- FreeSWITCH's pool allocator can mask some heap errors from ASan; module-owned
+  `new`/`malloc` are still covered.
+- Sanitizer builds are slow and memory-hungry — not for production; a dev/staging
+  FS host.
+- Static substitute (no run): `clang-tidy` with `clang-analyzer-*` /
+  `bugprone-*` / `concurrency-*` checks, run inside the FS tree (so headers
+  resolve), plus `cppcheck`. These find some issues statically but are not a
+  replacement for a TSan run under live calls.

--- a/tests/soak/Dockerfile
+++ b/tests/soak/Dockerfile
@@ -20,5 +20,14 @@ RUN g++ -std=c++11 -g -O1 -fsanitize=address,undefined -fno-omit-frame-pointer \
         soak_audiopipe.cpp audio_pipe.cpp $(pkg-config --cflags --libs libwebsockets) -lpthread -o soak_asan
 RUN g++ -std=c++11 -g -O1 -fsanitize=thread -fno-omit-frame-pointer \
         soak_audiopipe.cpp audio_pipe.cpp $(pkg-config --cflags --libs libwebsockets) -lpthread -o soak_tsan
+# deepgram AudioPipe variant (same lws transport lineage; TLS-only dialer, so
+# every connect terminates via CONNECT_FAIL against the plain-ws mock -- see
+# soak_deepgram.cpp for exactly what that does and does not exercise)
+COPY modules/mod_deepgram_transcribe/audio_pipe.cpp modules/mod_deepgram_transcribe/audio_pipe.hpp tests/soak/soak_deepgram.cpp dg/
+COPY tests/soak/tsan.supp ./
+RUN g++ -std=c++11 -g -O1 -fsanitize=address,undefined -fno-omit-frame-pointer \
+        dg/soak_deepgram.cpp dg/audio_pipe.cpp $(pkg-config --cflags --libs libwebsockets) -lpthread -o soak_dg_asan
+RUN g++ -std=c++11 -g -O1 -fsanitize=thread -fno-omit-frame-pointer \
+        dg/soak_deepgram.cpp dg/audio_pipe.cpp $(pkg-config --cflags --libs libwebsockets) -lpthread -o soak_dg_tsan
 RUN chmod +x run.sh
 CMD ["./run.sh"]

--- a/tests/soak/Dockerfile
+++ b/tests/soak/Dockerfile
@@ -1,0 +1,24 @@
+# Concurrency soak of the REAL mod_audio_fork AudioPipe under ASan + TSan.
+# Build context MUST be the repo root so the live module sources are used:
+#
+#   docker build -f tests/soak/Dockerfile -t audiopipe-soak .
+#   docker run --rm --security-opt seccomp=unconfined audiopipe-soak
+#
+# AudioPipe depends only on libwebsockets + std (no FreeSWITCH), so this drives
+# the real lws service thread, a media-thread writer, and the teardown/reaper
+# concurrently against a mock ws server. seccomp=unconfined lets setarch/TSan run.
+FROM debian:trixie
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ libwebsockets-dev pkg-config ca-certificates util-linux \
+    python3 python3-websockets && rm -rf /var/lib/apt/lists/*
+WORKDIR /opt/soak
+# the REAL module source (build context = repo root)
+COPY modules/mod_audio_fork/audio_pipe.cpp modules/mod_audio_fork/audio_pipe.hpp ./
+COPY tests/soak/soak_audiopipe.cpp tests/soak/ws_mock.py tests/soak/run.sh ./
+RUN g++ -std=c++11 -g -O1 -fsanitize=address,undefined -fno-omit-frame-pointer \
+        soak_audiopipe.cpp audio_pipe.cpp $(pkg-config --cflags --libs libwebsockets) -lpthread -o soak_asan
+RUN g++ -std=c++11 -g -O1 -fsanitize=thread -fno-omit-frame-pointer \
+        soak_audiopipe.cpp audio_pipe.cpp $(pkg-config --cflags --libs libwebsockets) -lpthread -o soak_tsan
+RUN chmod +x run.sh
+CMD ["./run.sh"]

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -1,0 +1,42 @@
+# AudioPipe concurrency soak (ASan + TSan)
+
+A Dockerized concurrency soak of the **real** `mod_audio_fork` `AudioPipe` —
+the WebSocket transport whose lifecycle (connect / stream / far-end drop /
+graceful close / rapid restart / connect-fail / reaper teardown / shutdown) is
+the most concurrency-sensitive code in the maintained modules.
+
+`AudioPipe` depends only on libwebsockets + the C++ stdlib (no FreeSWITCH), so it
+can be driven directly: the real lws service thread, a media-thread writer that
+fills the ring buffer exactly like `fork_frame`, and the teardown/reaper
+(`close` → `waitForClose` → delete via `shared_ptr`, capturing by value) all run
+concurrently in a 200-iteration × 4-worker loop against a mock ws server — built
+**twice from the same real source**, once with ASan/UBSan/LeakSanitizer and once
+with ThreadSanitizer.
+
+## Run
+
+```sh
+# from the repo root (build context must be the repo root):
+docker build -f tests/soak/Dockerfile -t audiopipe-soak .
+docker run --rm --security-opt seccomp=unconfined audiopipe-soak
+```
+
+`seccomp=unconfined` is needed so `setarch -R` (disables ASLR — required for TSan
+on recent kernels) and the sanitizer runtimes work. Exit 0 / `OVERALL: PASS`
+means ASan and TSan were both clean.
+
+## What it does and doesn't cover
+
+- **Covers:** data races, use-after-free, double-free, heap overflow, and leaks
+  in the `AudioPipe` transport + lifecycle + the shutdown (`deinitialize`) path.
+- **Does not cover:** the FreeSWITCH glue (`lws_glue.cpp`: media-bug lifecycle,
+  `eventCallback`, `fork_session_cleanup`) which needs the FS runtime, and the
+  google/aws/azure vendor SDK paths (gRPC / SigV4-HTTP2 / MS Speech SDK) which
+  need real backends — see `../SANITIZERS.md`. Those remain a real-credentials
+  live soak.
+
+## Scenarios (per iteration, round-robin)
+
+graceful stop · hangup-mid-stream · far-end drop (mock server closes mid-stream) ·
+rapid restart · connect-fail (dead port). The mock server also pushes occasional
+inbound JSON to exercise the receive path.

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -1,9 +1,19 @@
 # AudioPipe concurrency soak (ASan + TSan)
 
-A Dockerized concurrency soak of the **real** `mod_audio_fork` `AudioPipe` —
-the WebSocket transport whose lifecycle (connect / stream / far-end drop /
-graceful close / rapid restart / connect-fail / reaper teardown / shutdown) is
-the most concurrency-sensitive code in the maintained modules.
+A Dockerized concurrency soak of the **real** lws `AudioPipe` transports —
+since v0.6.0 it builds and runs BOTH the `mod_audio_fork` pipe and the
+`mod_deepgram_transcribe` pipe (`tests/soak/soak_deepgram.cpp`). The lifecycle
+under test (connect / stream / far-end drop / graceful close / rapid restart /
+connect-fail / reaper teardown / shutdown) is the most concurrency-sensitive
+code in the maintained modules.
+
+The deepgram variant dials TLS unconditionally, so against the plain-ws mock
+every connect terminates via CONNECT_FAIL — it exercises the connect-adoption,
+pre-handshake `finish()`, reaper-promise, and destructor/pending-list surfaces
+(with a 200/200 reaper-completion gate); its receive path is byte-identical to
+the mod_ttsd_transcribe AudioPipe, soaked end-to-end over plain ws in that
+repo. lws-internal logging races are suppressed via `tsan.supp` (library-only
+frames; module frames are never suppressed).
 
 `AudioPipe` depends only on libwebsockets + the C++ stdlib (no FreeSWITCH), so it
 can be driven directly: the real lws service thread, a media-thread writer that

--- a/tests/soak/run.sh
+++ b/tests/soak/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Run the AudioPipe concurrency soak under ASan and TSan against the mock ws.
+set -u
+cd /opt/soak
+rc=0
+
+run_one() {
+  local label="$1" bin="$2"
+  echo "================== ${label} =================="
+  WS_PORT=9000 python3 ws_mock.py 9000 >/tmp/ws9000.log 2>&1 &  W1=$!
+  WS_DROP_AFTER=0.3 WS_PORT=9001 python3 ws_mock.py 9001 >/tmp/ws9001.log 2>&1 & W2=$!
+  sleep 1
+  ITER="${ITER:-200}" WORKERS="${WORKERS:-4}" WS_PORT=9000 WS_DROP_PORT=9001 setarch -R ./"$bin"
+  local r=$?
+  kill $W1 $W2 2>/dev/null; wait $W1 $W2 2>/dev/null
+  if [ $r -ne 0 ]; then echo ">>> ${label}: sanitizer/exit error (rc=$r)"; rc=1; else echo ">>> ${label}: clean (exit 0)"; fi
+  echo
+}
+
+export ASAN_OPTIONS="detect_leaks=1:halt_on_error=1:abort_on_error=1:detect_stack_use_after_return=1"
+export TSAN_OPTIONS="halt_on_error=0:second_deadlock_stack=1:history_size=4"
+
+run_one "ASan + UBSan + LeakSanitizer" soak_asan
+run_one "ThreadSanitizer" soak_tsan
+
+echo "================== OVERALL: $([ $rc -eq 0 ] && echo PASS || echo FAIL) =================="
+exit $rc

--- a/tests/soak/run.sh
+++ b/tests/soak/run.sh
@@ -20,8 +20,16 @@ run_one() {
 export ASAN_OPTIONS="detect_leaks=1:halt_on_error=1:abort_on_error=1:detect_stack_use_after_return=1"
 export TSAN_OPTIONS="halt_on_error=0:second_deadlock_stack=1:history_size=4"
 
-run_one "ASan + UBSan + LeakSanitizer" soak_asan
-run_one "ThreadSanitizer" soak_tsan
+run_one "mod_audio_fork AudioPipe: ASan + UBSan + LeakSanitizer" soak_asan
+run_one "mod_audio_fork AudioPipe: ThreadSanitizer" soak_tsan
+
+run_one "mod_deepgram_transcribe AudioPipe: ASan + UBSan + LeakSanitizer" soak_dg_asan
+# lws-internal logging races are suppressed for the deepgram run (see tsan.supp;
+# our own frames are never suppressed by a called_from_lib rule)
+SAVED_TSAN="$TSAN_OPTIONS"
+export TSAN_OPTIONS="$TSAN_OPTIONS:suppressions=/opt/soak/tsan.supp"
+run_one "mod_deepgram_transcribe AudioPipe: ThreadSanitizer" soak_dg_tsan
+export TSAN_OPTIONS="$SAVED_TSAN"
 
 echo "================== OVERALL: $([ $rc -eq 0 ] && echo PASS || echo FAIL) =================="
 exit $rc

--- a/tests/soak/soak_audiopipe.cpp
+++ b/tests/soak/soak_audiopipe.cpp
@@ -1,0 +1,120 @@
+// Standalone concurrency soak of the REAL mod_audio_fork AudioPipe.
+// Drives, concurrently and in a loop: the lws service thread (started by
+// AudioPipe::initialize), a "media thread" that writes audio into the ring buffer
+// exactly like fork_frame does, and the teardown/reaper sequence
+// (close -> waitForClose -> delete via shared_ptr on a detached thread, capturing
+// by value) exactly like fork_session_cleanup. Build under ASan or TSan to catch
+// use-after-free / heap errors / data races in the actual AudioPipe code.
+//
+// No FreeSWITCH: AudioPipe depends only on libwebsockets + std + a callback ptr.
+#include "audio_pipe.hpp"
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <thread>
+#include <vector>
+
+static std::atomic<long> g_events{0};
+static std::atomic<long> g_pipes{0};
+
+static void logger(int level, const char* line) {
+  // keep noise down; surface only lws errors
+  if (level == LLL_ERR) fprintf(stderr, "[lws] %s", line);
+}
+static void onNotify(const char*, const char*, AudioPipe::NotifyEvent_t, const char*) {
+  g_events.fetch_add(1, std::memory_order_relaxed);
+}
+
+static const char* HOST = "127.0.0.1";
+static int PORT = 9000;       // normal mock ws
+static int DROP_PORT = 9001;  // mock ws that drops mid-stream
+static int BAD_PORT = 1;      // connect-fail
+
+// media thread: mimic fork_frame writing 320-byte L16 frames into the ring buffer
+static void mediaThread(AudioPipe* ap, std::atomic<bool>* stop) {
+  while (!stop->load(std::memory_order_relaxed)) {
+    if (ap->getLwsState() == AudioPipe::LWS_CLIENT_CONNECTED) {
+      ap->lockAudioBuffer();
+      size_t avail = ap->binarySpaceAvailable();
+      if (avail < ap->binaryMinSpace()) {
+        ap->binaryWritePtrResetToZero();        // overrun path (LWS_PRE reset)
+      } else {
+        char* p = ap->binaryWritePtr();
+        size_t n = 320;
+        if (n <= ap->binarySpaceAvailable()) { memset(p, 0x11, n); ap->binaryWritePtrAdd(n); }
+      }
+      ap->unlockAudioBuffer();                  // queues a pending write
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+// reaper: identical ownership pattern to fork_session_cleanup (capture by value;
+// detached thread closes, waits for the socket-closed promise, then deletes).
+static void reap(AudioPipe* ap) {
+  std::shared_ptr<AudioPipe> sp(ap);
+  std::thread([sp]{ sp->close(); sp->waitForClose(); }).detach();
+}
+
+static void oneIteration(int i) {
+  int port = PORT;
+  if (i % 5 == 2) port = DROP_PORT;   // far-end drop scenario
+  if (i % 5 == 4) port = BAD_PORT;    // connect-fail scenario
+
+  char bug[] = "soakbug";
+  size_t buflen = LWS_PRE + 320 * 40;
+  AudioPipe* ap = new AudioPipe("soak-sess", HOST, (unsigned int)port, "/", 0 /*ssl*/,
+                                buflen, 640 /*minfree*/, "", "", bug, onNotify);
+  g_pipes.fetch_add(1, std::memory_order_relaxed);
+  ap->connect();
+
+  std::atomic<bool> stop{false};
+  std::thread mt(mediaThread, ap, &stop);
+  std::this_thread::sleep_for(std::chrono::milliseconds(20 + (i % 30)));
+
+  switch (i % 5) {
+    case 0: ap->do_graceful_shutdown(); break;          // graceful (zero-len frame)
+    case 3: ap->bufferForSending("{\"type\":\"x\"}"); break; // text + rapid teardown
+    default: break;                                      // close/drop/connect-fail
+  }
+  // In real FS the media bug is removed (media stops) before the reaper runs.
+  stop.store(true, std::memory_order_relaxed);
+  mt.join();
+  reap(ap);   // hand off ownership; detached close+waitForClose+delete
+}
+
+int main(int argc, char** argv) {
+  int iters   = getenv("ITER")    ? atoi(getenv("ITER"))    : 200;
+  int workers = getenv("WORKERS") ? atoi(getenv("WORKERS")) : 4;
+  if (getenv("WS_PORT"))      PORT      = atoi(getenv("WS_PORT"));
+  if (getenv("WS_DROP_PORT")) DROP_PORT = atoi(getenv("WS_DROP_PORT"));
+
+  AudioPipe::initialize("audio.drachtio.org", 1 /*service threads*/, LLL_ERR, logger);
+  // wait for the service thread to create the lws context before any connect
+  // (in FreeSWITCH, initialize runs at module load, long before the first call)
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+
+  std::vector<std::thread> ws;
+  std::atomic<int> next{0};
+  for (int w = 0; w < workers; w++) {
+    ws.emplace_back([&]{
+      for (;;) {
+        int i = next.fetch_add(1);
+        if (i >= iters) break;
+        oneIteration(i);
+      }
+    });
+  }
+  for (auto& t : ws) t.join();
+
+  // let detached reapers drain (waitForClose returns on CLOSED/CONNECT_FAIL)
+  std::this_thread::sleep_for(std::chrono::seconds(3));
+  AudioPipe::deinitialize();
+
+  fprintf(stderr, "SOAK DONE: pipes=%ld events=%ld iters=%d workers=%d\n",
+          g_pipes.load(), g_events.load(), iters, workers);
+  return 0;
+}

--- a/tests/soak/soak_deepgram.cpp
+++ b/tests/soak/soak_deepgram.cpp
@@ -1,0 +1,127 @@
+// Concurrency soak of the REAL mod_deepgram_transcribe AudioPipe under
+// ASan/TSan. Deepgram's pipe always dials TLS (LCCSCF_USE_SSL), so against a
+// plain-ws mock or a refused port every connect terminates via
+// LWS_CALLBACK_CLIENT_CONNECTION_ERROR -> CONNECT_FAIL -> setClosed(). That
+// still concurrently exercises: addPendingConnect (round-robin + NULL-context
+// guard), findAndRemovePendingConnect, finish() pre-handshake
+// (m_gracefulShutdown path), the reaper promise, ~AudioPipe()
+// removeFromPending, and deinitialize() -- the teardown surfaces changed in
+// this release. The RECEIVE-path changes are exercised by the identical
+// mod_ttsd_transcribe soak (ws, no TLS) in that repo.
+#include "audio_pipe.hpp"
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using namespace deepgram;
+
+static std::atomic<long> g_events{0};
+static std::atomic<long> g_pipes{0};
+static std::atomic<long> g_completed{0};
+
+static void logger(int level, const char* line) {
+  if (level == LLL_ERR) fprintf(stderr, "[lws] %s", line);
+}
+static void onNotify(const char*, AudioPipe::NotifyEvent_t event, const char* message, bool) {
+  g_events.fetch_add(1, std::memory_order_relaxed);
+  if (event == AudioPipe::CONNECT_FAIL && message) {
+    // touch the message (ASan checks the buffer) -- may legitimately be NULL
+    volatile size_t n = strlen(message);
+    (void) n;
+  }
+}
+
+static const char* HOST = "127.0.0.1";
+static int PORT = 9000;       // plain-ws mock: TLS handshake fails -> CONNECT_FAIL
+static int BAD_PORT = 1;      // connection refused -> CONNECT_FAIL
+static const char* PATH = "/v1/listen";
+
+static void mediaThread(AudioPipe* ap, std::atomic<bool>* stop) {
+  while (!stop->load(std::memory_order_relaxed)) {
+    if (ap->getLwsState() == AudioPipe::LWS_CLIENT_CONNECTED) {
+      ap->lockAudioBuffer();
+      size_t avail = ap->binarySpaceAvailable();
+      if (avail < ap->binaryMinSpace()) {
+        ap->binaryWritePtrResetToZero();
+      } else {
+        char* p = ap->binaryWritePtr();
+        size_t n = 320;
+        if (n <= ap->binarySpaceAvailable()) { memset(p, 0x11, n); ap->binaryWritePtrAdd(n); }
+      }
+      ap->unlockAudioBuffer();
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+// identical ownership pattern to the glue's reaper()
+static void reap(AudioPipe* ap) {
+  std::shared_ptr<AudioPipe> sp(ap);
+  std::thread([sp]{
+    sp->finish();
+    sp->waitForClose();
+    g_completed.fetch_add(1, std::memory_order_relaxed);
+  }).detach();
+}
+
+static void oneIteration(int i) {
+  int port = (i % 3 == 2) ? BAD_PORT : PORT;
+  size_t buflen = LWS_PRE + 320 * 40;
+  AudioPipe* ap = new AudioPipe("soak-sess", HOST, (unsigned int)port, PATH,
+                                buflen, 640, "fake-api-key", onNotify);
+  g_pipes.fetch_add(1, std::memory_order_relaxed);
+  ap->connect();
+
+  std::atomic<bool> stop{false};
+  std::thread mt(mediaThread, ap, &stop);
+  if (i % 4 != 3) {
+    // 3 of 4 iterations wait a bit; the 4th reaps IMMEDIATELY after connect(),
+    // racing finish() against the (failing) handshake -- the pre-handshake
+    // finish/m_gracefulShutdown path plus CONNECT_FAIL's own setClosed()
+    std::this_thread::sleep_for(std::chrono::milliseconds(5 + (i % 25)));
+  }
+  if (i % 4 == 0) ap->finish();  // some explicit early finishes
+  stop.store(true, std::memory_order_relaxed);
+  mt.join();
+  reap(ap);
+}
+
+int main() {
+  int iters   = getenv("ITER")    ? atoi(getenv("ITER"))    : 200;
+  int workers = getenv("WORKERS") ? atoi(getenv("WORKERS")) : 4;
+  if (getenv("WS_PORT")) PORT = atoi(getenv("WS_PORT"));
+
+  AudioPipe::initialize(2 /*service threads: exercise the per-context filtering*/, LLL_ERR, logger);
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+
+  std::vector<std::thread> ws;
+  std::atomic<int> next{0};
+  for (int w = 0; w < workers; w++) {
+    ws.emplace_back([&]{
+      for (;;) {
+        int i = next.fetch_add(1);
+        if (i >= iters) break;
+        oneIteration(i);
+      }
+    });
+  }
+  for (auto& t : ws) t.join();
+
+  // let detached reapers drain (CONNECT_FAIL fulfills the close promise)
+  for (int i = 0; i < 30 && g_completed.load() < iters; i++)
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+  long completed = g_completed.load();
+  bool ok = completed >= iters;
+  fprintf(stderr, "%s: %ld/%d reapers completed (pipes=%ld events=%ld)\n",
+          ok ? "REAPER PASS" : "REAPER FAIL (waitForClose leak)", completed, iters, g_pipes.load(), g_events.load());
+
+  AudioPipe::deinitialize();
+  fprintf(stderr, "SOAK DONE\n");
+  return ok ? 0 : 1;
+}

--- a/tests/soak/tsan.supp
+++ b/tests/soak/tsan.supp
@@ -1,0 +1,7 @@
+# ThreadSanitizer suppressions for the AudioPipe soaks.
+#
+# libwebsockets-internal only: its logging/date-string path shares a global
+# buffer across service threads (lws_snprintf into a static). Third-party
+# code -- races whose every frame is inside libwebsockets.so. Our own frames
+# are never suppressed by this rule.
+called_from_lib:libwebsockets.so

--- a/tests/soak/ws_mock.py
+++ b/tests/soak/ws_mock.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Minimal mock WebSocket sink for mod_audio_fork / mod_deepgram_transcribe soak.
+# Accepts connections, drains audio frames, optionally sends back a small JSON
+# message periodically (to exercise the inbound receive path), and supports a
+# "drop after N seconds" mode to simulate far-end disconnects.
+import asyncio, sys, os
+try:
+    import websockets
+except Exception as e:
+    sys.stderr.write("FATAL: python websockets not available: %s\n" % e)
+    sys.exit(2)
+
+PORT = int(os.environ.get("WS_PORT", sys.argv[1] if len(sys.argv) > 1 else "9000"))
+DROP_AFTER = float(os.environ.get("WS_DROP_AFTER", "0"))  # 0 = never drop
+
+async def handler(*args):
+    ws = args[0]
+    n = 0
+    try:
+        if DROP_AFTER > 0:
+            async def killer():
+                await asyncio.sleep(DROP_AFTER)
+                await ws.close()
+            asyncio.ensure_future(killer())
+        async for msg in ws:
+            n += 1
+            # occasionally push an inbound JSON message back to the module to
+            # exercise its receive/parse path (mod_audio_fork handles playAudio etc.)
+            if n % 200 == 0:
+                try:
+                    await ws.send('{"type":"transcription","data":{"is_final":false,"text":"soak"}}')
+                except Exception:
+                    break
+    except Exception:
+        pass
+
+async def main():
+    # negotiate the audio.drachtio.org subprotocol that the libwebsockets client offers
+    async with websockets.serve(handler, "127.0.0.1", PORT, max_size=None, ping_interval=None,
+                                subprotocols=["audio.drachtio.org"]):
+        sys.stderr.write("ws_mock listening on 127.0.0.1:%d (drop_after=%s)\n" % (PORT, DROP_AFTER))
+        await asyncio.Future()
+
+asyncio.run(main())

--- a/tests/test_base64.cpp
+++ b/tests/test_base64.cpp
@@ -1,0 +1,44 @@
+// Host unit tests for modules/mod_*/base64.hpp (drachtio::base64_encode/decode).
+// base64.hpp is pure, header-only, and FreeSWITCH-independent.
+#include "test_util.h"
+#include "base64.hpp"
+
+using drachtio::base64_encode;
+using drachtio::base64_decode;
+
+// RFC 4648 §10 test vectors.
+TEST("rfc4648 encode vectors") {
+  CHECK_EQ(base64_encode(std::string("")),       std::string(""));
+  CHECK_EQ(base64_encode(std::string("f")),      std::string("Zg=="));
+  CHECK_EQ(base64_encode(std::string("fo")),     std::string("Zm8="));
+  CHECK_EQ(base64_encode(std::string("foo")),    std::string("Zm9v"));
+  CHECK_EQ(base64_encode(std::string("foob")),   std::string("Zm9vYg=="));
+  CHECK_EQ(base64_encode(std::string("fooba")),  std::string("Zm9vYmE="));
+  CHECK_EQ(base64_encode(std::string("foobar")), std::string("Zm9vYmFy"));
+}
+
+TEST("rfc4648 decode vectors") {
+  CHECK_EQ(base64_decode(std::string("")),         std::string(""));
+  CHECK_EQ(base64_decode(std::string("Zg==")),     std::string("f"));
+  CHECK_EQ(base64_decode(std::string("Zm8=")),     std::string("fo"));
+  CHECK_EQ(base64_decode(std::string("Zm9v")),     std::string("foo"));
+  CHECK_EQ(base64_decode(std::string("Zm9vYg==")), std::string("foob"));
+  CHECK_EQ(base64_decode(std::string("Zm9vYmE=")), std::string("fooba"));
+  CHECK_EQ(base64_decode(std::string("Zm9vYmFy")), std::string("foobar"));
+}
+
+TEST("round-trip over all byte values") {
+  std::string raw;
+  for (int i = 0; i < 256; i++) raw.push_back(static_cast<char>(i));
+  CHECK_EQ(base64_decode(base64_encode(raw)), raw);
+}
+
+TEST("encode from buffer + length matches string overload") {
+  const unsigned char buf[] = {0x00, 0xff, 0x10, 0x80, 0x7f};
+  std::string a = base64_encode(buf, sizeof(buf));
+  std::string b = base64_encode(std::string(reinterpret_cast<const char*>(buf), sizeof(buf)));
+  CHECK_EQ(a, b);
+  CHECK_EQ(base64_decode(a), std::string(reinterpret_cast<const char*>(buf), sizeof(buf)));
+}
+
+int main() { return tu::run(); }

--- a/tests/test_simple_buffer.cpp
+++ b/tests/test_simple_buffer.cpp
@@ -1,0 +1,68 @@
+// Host unit tests for modules/mod_*/simple_buffer.h (SimpleBuffer).
+// These exercise the bugs that were fixed: reads must return the OLDEST written
+// chunk (not the next write slot) even on a partial fill, getNextChunk() must not
+// underflow when empty, and overwrite must drop the oldest chunk in FIFO order.
+#include <cstring>
+#include <cstdint>
+#include "test_util.h"
+#include "simple_buffer.h"
+
+// Helper: a chunk is 4 bytes here; build a 4-byte chunk from a tag char.
+static void chunk(char tag, char out[4]) { std::memset(out, tag, 4); }
+
+TEST("partial fill: read returns oldest written chunk, in order") {
+  SimpleBuffer b(4, 8);            // 4-byte chunks, capacity 8
+  char a[4], c[4];
+  chunk('A', a); chunk('C', c);
+  b.add(a, 4);
+  b.add(c, 4);
+  CHECK_EQ(b.getNumItems(), 2u);
+
+  char* p1 = b.getNextChunk();
+  CHECK(p1 != nullptr);
+  CHECK(p1 != nullptr && p1[0] == 'A');   // oldest first, NOT a write-slot
+  char* p2 = b.getNextChunk();
+  CHECK(p2 != nullptr && p2[0] == 'C');
+  CHECK_EQ(b.getNumItems(), 0u);
+}
+
+TEST("empty buffer: getNextChunk returns null and does not underflow") {
+  SimpleBuffer b(4, 8);
+  CHECK(b.getNextChunk() == nullptr);
+  CHECK_EQ(b.getNumItems(), 0u);
+  // Call again past empty — must stay 0, not wrap to a huge unsigned value.
+  CHECK(b.getNextChunk() == nullptr);
+  CHECK_EQ(b.getNumItems(), 0u);
+}
+
+TEST("multi-chunk add splits by chunk size") {
+  SimpleBuffer b(4, 8);
+  char two[8];
+  std::memset(two, 'X', 4);
+  std::memset(two + 4, 'Y', 4);
+  b.add(two, 8);                   // one add, two chunks
+  CHECK_EQ(b.getNumItems(), 2u);
+  CHECK(b.getNextChunk()[0] == 'X');
+  CHECK(b.getNextChunk()[0] == 'Y');
+}
+
+TEST("non-multiple length is rejected") {
+  SimpleBuffer b(4, 8);
+  char odd[3] = {'z', 'z', 'z'};
+  b.add(odd, 3);
+  CHECK_EQ(b.getNumItems(), 0u);
+}
+
+TEST("overwrite when full drops oldest in FIFO order") {
+  SimpleBuffer b(4, 3);            // capacity 3
+  char c[4];
+  for (char t = '1'; t <= '4'; t++) { chunk(t, c); b.add(c, 4); }  // 1,2,3,4
+  CHECK_EQ(b.getNumItems(), 3u);  // saturated at capacity
+  // Oldest ('1') was overwritten by '4'; remaining oldest->newest = 2,3,4.
+  CHECK(b.getNextChunk()[0] == '2');
+  CHECK(b.getNextChunk()[0] == '3');
+  CHECK(b.getNextChunk()[0] == '4');
+  CHECK(b.getNextChunk() == nullptr);
+}
+
+int main() { return tu::run(); }

--- a/tests/test_util.h
+++ b/tests/test_util.h
@@ -1,0 +1,58 @@
+// Minimal, dependency-free test harness for host-side unit tests of
+// FreeSWITCH-independent logic. No external framework (the build is offline and
+// we do not want to vendor one). Usage:
+//
+//   #include "test_util.h"
+//   TEST(name) { CHECK(cond); CHECK_EQ(a, b); }
+//   int main() { return tu::run(); }
+#ifndef TEST_UTIL_H
+#define TEST_UTIL_H
+
+#include <cstdio>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace tu {
+
+struct Case { std::string name; std::function<void()> fn; };
+
+inline std::vector<Case>& cases() { static std::vector<Case> c; return c; }
+inline int& failures() { static int f = 0; return f; }
+
+struct Reg { Reg(const std::string& n, std::function<void()> fn) { cases().push_back({n, fn}); } };
+
+inline void fail(const char* file, int line, const std::string& msg) {
+  failures()++;
+  std::fprintf(stderr, "  FAIL %s:%d: %s\n", file, line, msg.c_str());
+}
+
+inline int run() {
+  int passed = 0;
+  for (auto& c : cases()) {
+    int before = failures();
+    c.fn();
+    if (failures() == before) { std::printf("  ok   %s\n", c.name.c_str()); passed++; }
+    else                      { std::printf("  bad  %s\n", c.name.c_str()); }
+  }
+  std::printf("%d/%zu test(s) passed\n", passed, cases().size());
+  return failures() == 0 ? 0 : 1;
+}
+
+} // namespace tu
+
+#define TU_CONCAT2(a, b) a##b
+#define TU_CONCAT(a, b) TU_CONCAT2(a, b)
+#define TEST(name)                                                            \
+  static void TU_CONCAT(tu_case_, __LINE__)();                                \
+  static tu::Reg TU_CONCAT(tu_reg_, __LINE__)(name, TU_CONCAT(tu_case_, __LINE__)); \
+  static void TU_CONCAT(tu_case_, __LINE__)()
+
+#define CHECK(cond) \
+  do { if (!(cond)) tu::fail(__FILE__, __LINE__, "CHECK(" #cond ")"); } while (0)
+
+#define CHECK_EQ(a, b) \
+  do { auto va = (a); auto vb = (b); if (!(va == vb)) \
+       tu::fail(__FILE__, __LINE__, "CHECK_EQ(" #a ", " #b ")"); } while (0)
+
+#endif // TEST_UTIL_H


### PR DESCRIPTION
  ## What
                                                                                                                                                                                                                                                                                                                                                                   
  Convert 12 `switch_log_printf(SWITCH_CHANNEL_LOG, ...)` calls in `mod_audio_fork`
  to use the session/channel-aware log macros, so `mod_syslog`'s                                                                                                                                                                                                                                                                                                   
  `"%s %s"` handler can stamp each emitted line with the channel UUID.
                                                                                                                                                                                                                                                                                                                                                                   
  | Site | Before | After |                                                                                                                                                                                                                                                                                                                                        
  |---|---|---|                                                                                                                                                                                                                                                                                                                                                    
  | `processIncomingMessage` (5 calls) | `SWITCH_CHANNEL_LOG` | `SWITCH_CHANNEL_SESSION_LOG(session)` |                                                                                                                                                                                                                                                            
  | `destroy_tech_pvt` (1 call) | `SWITCH_CHANNEL_LOG`, `"%s ..."` with `tech_pvt->sessionId` in the format | `SWITCH_CHANNEL_UUID_LOG(tech_pvt->sessionId)`, leading `%s` removed to avoid double-prefix |                                                                                                                                                        
  | `parse_ws_uri` (6 calls) | `SWITCH_CHANNEL_LOG` | `SWITCH_CHANNEL_CHANNEL_LOG(channel)` |                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                   
  7 sites are intentionally **left** on `SWITCH_CHANNEL_LOG`:                                                                                                                                                                                                                                                                                                      
  the libwebsockets logger callback (no FS context available),                                                                                                                                                                                                                                                                                                     
  `fork_init()`, and `mod_audio_fork.c`'s API-load lines.                                                                                                                                                                                                                                                                                                          
  Module-load runs before any session exists.                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                   
  ## Why                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                   
  `mod_syslog`'s log handler is hard-coded to:                                                                                                                                                                                                                                                                                                                     
  ```c                                                                                                                                                                                                                                                                                                                                                             
  syslog(level, "%s %s", node->userdata, node->data);
  when node->userdata is non-empty. That field is set by the                                                                                                                                                                                                                                                                                                       
  SWITCH_CHANNEL_*_LOG macros — SWITCH_CHANNEL_LOG passes NULL,                                                                                                                                                                                                                                                                                                    
  which produces un-prefixed lines.                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                   
  In a busy deployment, journalctl | grep <call-sid> is the fastest                                                                                                                                                                                                                                                                                                
  way to assemble a per-call timeline, but it only works if every                                                                                                                                                                                                                                                                                                  
  relevant log line carries the UUID. The rest of mod_audio_fork                                                                                                                                                                                                                                                                                                   
  already uses SESSION_LOG correctly (eventCallback lines 169, 172,                                                                                                                                                                                                                                                                                                
  184, 191) — these 12 sites look like oversights rather than                                                                                                                                                                                                                                                                                                      
  deliberate design.                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                   
  Bonus: dead-code cleanup                                                                                                                                                                                                                                                                                                                                         
                                                                                
  While in lws_glue.cpp, cppcheck --enable=warning,style flagged five                                                                                                                                                                                                                                                                                              
  declared-but-never-read locals: inuse, dirty, p in fork_frame;                
  i, saveptr in parse_ws_uri; err in fork_session_init. Looks                                                                                                                                                                                                                                                                                                      
  like leftovers from earlier refactors. Removed in the second commit;                                                                                                                                                                                                                                                                                             
  no behavioural change. Happy to split into a separate PR if you'd                                                                                                                                                                                                                                                                                                
  prefer.                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                   
  Testing                                                                                                                                                                                                                                                                                                                                                          
                                                                                
  - cppcheck --enable=warning,style,performance,portability — no new                                                                                                                                                                                                                                                                                               
  warnings; 5 pre-existing unused-locals warnings cleared.
  - Full FreeSWITCH-linked compile + load on Debian Trixie + FS 1.10.12.                                                                                                                                                                                                                                                                                           
  - Live calls passing audio through audio_fork (WS sub-protocol):                                                                                                                                                                                                                                                                                                 
  verified the converted lines now appear in journalctl with the                                                                                                                                                                                                                                                                                                   
  channel UUID prefix.                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                   
  Compatibility                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                   
  No public API changes; macro selection is purely a logging detail.                                                                                                                                                                                                                                                                                               
  All existing tech_pvt field accesses unchanged.
                                                                                                                                                                                                                                                                                                                                                                   
  A few notes on tone:                                                                                                                                                                                                                                                                                                                                             
  - **Cite the exact source** (the `"%s %s"` line in mod_syslog). Maintainers appreciate when you've read their code, not assumed.
  - **Acknowledge what stays as-is** so they know you considered the call sites individually, not blanket-replaced.                                                                                                                                                                                                                                                
  - **Offer to split** the dead-code commit. Maintainers often prefer single-purpose PRs; offering shows you respect their workflow.                                                                                                                                                                                                                               
  - **Skip the "Co-Authored-By" / generated trailers** — just clean attribution per your global git rule.                                                                                                                                                                                                                                                          
